### PR TITLE
Adapt the grammar to properly detect some edge-cases

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -726,11 +726,13 @@ module.exports = grammar({
     // so as to obtain a node in the CST.
     //
     string_content: _ => token.immediate(prec(1, /[^"\\]+/)),
-    _multiline_string_content: _ =>
-      prec.right(choice(
-        /[^"]+/,
-        seq(/"[^"]*/, repeat(/[^"]+/)),
-      )),
+    _multiline_string_content: $ => prec.right(choice(
+      /[^"]+/,
+      seq(/"[^"]*/, repeat(/[^"]+/)),
+      // To account for content that ends in a quote immediately followed by the triple quote
+      // e.g. """"Foo"""" will be parsed as """, content: "Foo", """
+      $._string_literal,
+    )),
 
 
     _escape_sequence: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -263,7 +263,6 @@ module.exports = grammar({
       $.viewpoint_type,
       $.lambda_type,
       $.this,
-      $.none,
     ),
 
     base_type: $ => prec.right(seq(
@@ -355,7 +354,6 @@ module.exports = grammar({
       $.identifier,
       $.ffi_identifier,
       $.this,
-      $.none,
       $.error,
       $.compile_intrinsic,
       $.compile_error,
@@ -757,8 +755,6 @@ module.exports = grammar({
     ffi_identifier: $ => seq('@', choice($.identifier, $.string)),
 
     this: _ => 'this',
-
-    none: _ => 'None',
 
     comment: _ => token(choice(
       seq('//', /(\\(.|\r?\n)|[^\\\n])*/),

--- a/grammar.js
+++ b/grammar.js
@@ -191,7 +191,7 @@ module.exports = grammar({
       $.parameters,
       optional('?'),
       optional(choice(
-        seq('=>', repeat1($.expression)),
+        seq('=>', $.block),
         $.string,
       )),
     ),
@@ -207,7 +207,7 @@ module.exports = grammar({
       optional(seq(':', field('returns', $.type))),
       optional('?'),
       optional(choice(
-        seq('=>', repeat1($.expression)),
+        seq('=>', $.block),
         $.string,
       )),
     ),
@@ -220,7 +220,7 @@ module.exports = grammar({
       optional($.generic_parameters),
       $.parameters,
       optional(choice(
-        seq('=>', repeat1($.expression)),
+        seq('=>', $.block),
         $.string,
       )),
     ),
@@ -313,16 +313,19 @@ module.exports = grammar({
       optional('@'),
       '{',
       optional($.capability),
+      optional($.identifier),
+      optional(alias($.generic_parameters, $.type_parameters)),
       '(',
       commaSep($.type),
       ')',
       optional(seq(':', $.type)),
       optional('?'),
-      optional(seq('=>', $.type)),
       '}',
     ),
 
     member_type: $ => prec.right(seq($.identifier, '.', $.type)),
+
+    block: $ => prec.left(seq($.expression, repeat(seq(optional(';'), $.expression)))),
 
     expression: $ => choice(
       $.unary_expression,
@@ -356,7 +359,14 @@ module.exports = grammar({
       $.ffi_identifier,
       $.this,
       $.none,
+      $.error,
+      $.compile_intrinsic,
+      $.compile_error,
     ),
+
+    error: _ => 'error',
+    compile_intrinsic: $ => 'compile_intrinsic',
+    compile_error: $ => prec.left(seq('compile_error', optional($.string))),
 
     unary_expression: $ => prec.left(PREC.UNARY, seq(
       field('operator', choice('-', 'not', '-~', 'addressof', 'digestof')),
@@ -391,11 +401,10 @@ module.exports = grammar({
       ')',
     )),
 
-    assignment_expression: $ => prec.right(PREC.ASSIGNMENT, seq(
+    assignment_expression: $ => prec.left(PREC.ASSIGNMENT, seq(
       $.expression,
       '=',
-      $.expression,
-      optional(';'),
+      $.block,
     )),
 
     variable_declaration: $ => prec.right(seq(
@@ -417,7 +426,6 @@ module.exports = grammar({
       optional($.named_arguments),
       ')',
       optional('?'),
-      optional(';'),
     )),
     named_arguments: $ => seq(
       'where',
@@ -435,19 +443,20 @@ module.exports = grammar({
       optional(seq(':', $.type)),
       optional('?'),
       '=>',
-      repeat(seq($.expression, optional(';'))),
+      $.block,
       '}',
       optional($.capability),
     ),
     lambda_parameter: $ => seq(
       $.identifier,
       optional(seq(':', $.type)),
-      optional(seq('=', $.literal)),
+      optional(seq('=', $.expression)),
     ),
     lambda_captures: $ => seq(
       '(',
       commaSep(seq(
         $.identifier,
+        optional(seq(':', $.type)),
         optional(seq('=', $.expression)),
       )),
       ')',
@@ -486,19 +495,19 @@ module.exports = grammar({
     if_block: $ => seq(
       choice('if', 'ifdef'),
       optional($.annotation),
-      $.expression,
+      $.block,
     ),
 
     then_block: $ => seq(
       'then',
       optional($.annotation),
-      repeat($.expression),
+      $.block,
     ),
 
     elseif_block: $ => seq(
       'elseif',
       optional($.annotation),
-      $.expression,
+      $.block,
       $.then_block,
     ),
 
@@ -523,7 +532,7 @@ module.exports = grammar({
     else_block: $ => seq(
       'else',
       optional($.annotation),
-      repeat1($.expression),
+      $.block,
     ),
 
     for_statement: $ => seq(
@@ -544,22 +553,27 @@ module.exports = grammar({
     try_statement: $ => seq(
       'try',
       optional($.annotation),
-      repeat(seq($.expression, optional(';'))),
+      $.block,
       optional($.else_block),
       optional($.then_block),
       'end',
     ),
-
+    with_elem: $ => seq(
+      $.identifier,
+      '=',
+      $.block,
+    ),
     with_statement: $ => seq(
       'with',
-      $.expression,
+      optional($.annotation),
+      commaSep1($.with_elem),
       $.do_block,
     ),
 
     repeat_statement: $ => seq(
       'repeat',
       optional($.annotation),
-      repeat1($.expression),
+      $.block,
       'until',
       optional($.annotation),
       $.expression,
@@ -569,7 +583,7 @@ module.exports = grammar({
 
     do_block: $ => seq(
       'do',
-      repeat1($.expression),
+      $.block,
       optional($.else_block),
       'end',
     ),
@@ -578,14 +592,14 @@ module.exports = grammar({
       'recover',
       optional($.annotation),
       optional($.capability),
-      repeat1($.expression),
+      $.block,
       'end',
     ),
 
     match_expression: $ => seq(
       'match',
       optional($.annotation),
-      $.expression,
+      $.block,
       repeat1($.case_statement),
       optional($.else_block),
       'end',
@@ -602,16 +616,16 @@ module.exports = grammar({
         $.if_block,
       ),
       '=>',
-      repeat(seq($.expression, optional(';'))),
+      $.block,
     ),
 
-    return_statement: _ => 'return',
+    return_statement: $ => prec.left(seq('return', optional($.block))),
 
-    continue_statement: _ => 'continue',
+    continue_statement: $ => prec.left(seq('continue', optional($.block))),
 
-    break_statement: _ => 'break',
+    break_statement: $ => prec.left(seq('break', optional($.block))),
 
-    consume_expression: $ => seq('consume', $.identifier),
+    consume_expression: $ => seq('consume', optional($.capability), $.identifier),
 
     generic_parameters: $ => seq(
       '[',
@@ -636,13 +650,7 @@ module.exports = grammar({
     array_literal: $ => seq(
       '[',
       optional(seq('as', $.type, ':')),
-      optional(seq(
-        $.expression,
-        repeat(seq(
-          optional(';'),
-          optional(seq('as', $.type, ':')),
-          $.expression,
-        )))),
+      optional($.block),
       ']',
     ),
 
@@ -690,23 +698,26 @@ module.exports = grammar({
       )),
       '"',
     ),
-    _multiline_string_literal: $ => seq(
+    _multiline_string_literal: $ => prec.right(seq(
       '"""',
       repeat(choice(
         alias($._multiline_string_content, $.string_content),
         $._escape_sequence,
       )),
       '"""',
-    ),
+    )),
 
     character: $ => seq(
       '\'',
-      choice(
-        token.immediate(prec(2, /[^'\\]/)),
-        $._escape_sequence,
+      repeat1(
+        choice(
+          $.character_content,
+          $._escape_sequence,
+        ),
       ),
       '\'',
     ),
+    character_content: _ => token.immediate(prec(2, /[^'\\]+/)),
 
     // Workaround to https://github.com/tree-sitter/tree-sitter/issues/1156
     // We give names to the token_ constructs containing a regexp

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,132 @@
+(comment) @comment
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  ";"
+  "."
+  ","
+] @punctuation.delimiter
+
+[
+  "if"
+  "ifdef"
+  "then"
+  "else"
+  "elseif"
+  "end"
+  "try"
+  "while"
+  "for"
+  "use"
+  "as"
+  "var"
+  "let"
+  "embed"
+  "fun"
+  "be"
+  "new"
+  "actor"
+  "class"
+  "struct"
+  "primitive"
+  "interface"
+  "trait"
+  "type"
+  "iso"
+  "trn"
+  "ref"
+  "val"
+  "box"
+  "tag"
+  "#read"
+  "#send"
+  "#share"
+  "#alias"
+  "#any"
+] @keyword
+
+;; Operators
+[
+ "?"
+ "=>"
+
+ "~"
+ ".>"
+
+ "+"
+ "-"
+ "*"
+ "/"
+ "%"
+ "%%"
+ "+~"
+ "-~"
+ "/~"
+ "*~"
+ "%~"
+ "%%~"
+
+ ">>"
+ "<<"
+ ">>~"
+ "<<~"
+
+ "=="
+ "!="
+ ">"
+ "<"
+ ">="
+ "<="
+
+ "and"
+ "or"
+ "xor"
+ "is"
+ "isnt"
+ "not"
+] @operator
+
+(boolean) @contant.builtin
+[
+  (number)
+  (float)
+] @number
+
+;; strings/docstrings
+(source_file . (string) @string.special)
+(actor_definition (identifier) @type (string)? @string.special)
+(class_definition (identifier) @type (string)? @string.special)
+(primitive_definition (identifier) @type (string)? @string.special)
+(interface_definition (identifier) @type (string)? @string.special)
+(trait_definition (identifier) @type (string)? @string.special)
+(struct_definition (identifier) @type (string)? @string.special)
+(type_alias (identifier) @type (string)? @string.special)
+
+(constructor (identifier) @constructor (string)? @string.special)
+(method (identifier) @function.method (string)? @string.special)
+(behavior (identifier) @function.method (string)? @string.special)
+(constructor (block . (literal (string)) @string.special))
+(method (block . (literal (string)) @string.special))
+(behavior (block . (literal (string)) @string.special))
+(string) @string
+
+(field name: (identifier) @property)
+(parameter name: (identifier) @variable.parameter)
+(lambda_parameter name: (identifier) @variable.parameter)
+
+; types
+(base_type name: (identifier)+ @type)
+(generic_parameter (identifier) @type)
+(lambda_type (identifier)? @function.method)
+
+; variables
+(variable_declaration (identifier) @variable)
+(identifier) @variable

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -832,8 +832,12 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
         },
         {
           "type": "STRING",
@@ -955,11 +959,8 @@
                       "value": "=>"
                     },
                     {
-                      "type": "REPEAT1",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "expression"
-                      }
+                      "type": "SYMBOL",
+                      "name": "block"
                     }
                   ]
                 },
@@ -1090,11 +1091,8 @@
                       "value": "=>"
                     },
                     {
-                      "type": "REPEAT1",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "expression"
-                      }
+                      "type": "SYMBOL",
+                      "name": "block"
                     }
                   ]
                 },
@@ -1176,11 +1174,8 @@
                       "value": "=>"
                     },
                     {
-                      "type": "REPEAT1",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "expression"
-                      }
+                      "type": "SYMBOL",
+                      "name": "block"
                     }
                   ]
                 },
@@ -1317,8 +1312,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "FIELD",
+              "name": "name",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
             },
             {
               "type": "STRING",
@@ -1374,27 +1373,39 @@
         },
         {
           "type": "SYMBOL",
-          "name": "generic_type"
+          "name": "read_type"
         },
         {
           "type": "SYMBOL",
-          "name": "tuple_type"
+          "name": "send_type"
         },
         {
           "type": "SYMBOL",
-          "name": "isolated_type"
+          "name": "share_type"
         },
         {
           "type": "SYMBOL",
-          "name": "transition_type"
+          "name": "alias_type"
         },
         {
           "type": "SYMBOL",
-          "name": "reference_type"
+          "name": "any_type"
         },
         {
           "type": "SYMBOL",
-          "name": "value_type"
+          "name": "iso_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "trn_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ref_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_type"
         },
         {
           "type": "SYMBOL",
@@ -1403,6 +1414,10 @@
         {
           "type": "SYMBOL",
           "name": "tag_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_type"
         },
         {
           "type": "SYMBOL",
@@ -1422,15 +1437,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "member_type"
-        },
-        {
-          "type": "SYMBOL",
           "name": "this"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "none"
         }
       ]
     },
@@ -1441,15 +1448,40 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "identifier"
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "."
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
           },
           {
             "type": "CHOICE",
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "type_capability"
+                "name": "type_args"
               },
               {
                 "type": "BLANK"
@@ -1459,28 +1491,283 @@
         ]
       }
     },
-    "type_capability": {
-      "type": "CHOICE",
+    "type_args": {
+      "type": "SEQ",
       "members": [
         {
           "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "type"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "read_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "base_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda_type"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
           "value": "#read"
+        }
+      ]
+    },
+    "send_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "base_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda_type"
+            }
+          ]
         },
         {
           "type": "STRING",
           "value": "#send"
+        }
+      ]
+    },
+    "share_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "base_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda_type"
+            }
+          ]
         },
         {
           "type": "STRING",
           "value": "#share"
+        }
+      ]
+    },
+    "alias_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "base_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda_type"
+            }
+          ]
         },
         {
           "type": "STRING",
           "value": "#alias"
+        }
+      ]
+    },
+    "any_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "base_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda_type"
+            }
+          ]
         },
         {
           "type": "STRING",
           "value": "#any"
+        }
+      ]
+    },
+    "iso_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "base_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda_type"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "iso"
+        }
+      ]
+    },
+    "trn_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "base_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda_type"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "trn"
+        }
+      ]
+    },
+    "ref_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "base_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda_type"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "ref"
+        }
+      ]
+    },
+    "val_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "base_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda_type"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "val"
+        }
+      ]
+    },
+    "box_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "base_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda_type"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "box"
+        }
+      ]
+    },
+    "tag_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "base_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda_type"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "tag"
         }
       ]
     },
@@ -1507,121 +1794,6 @@
         {
           "type": "STRING",
           "value": "^"
-        }
-      ]
-    },
-    "generic_type": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ffi_identifier"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "["
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "type"
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "="
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "type"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "type"
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "="
-                              },
-                              {
-                                "type": "SYMBOL",
-                                "name": "type"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "]"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "type_capability"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
         }
       ]
     },
@@ -1660,84 +1832,6 @@
         {
           "type": "STRING",
           "value": ")"
-        }
-      ]
-    },
-    "isolated_type": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "type"
-        },
-        {
-          "type": "STRING",
-          "value": "iso"
-        }
-      ]
-    },
-    "transition_type": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "type"
-        },
-        {
-          "type": "STRING",
-          "value": "trn"
-        }
-      ]
-    },
-    "reference_type": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "type"
-        },
-        {
-          "type": "STRING",
-          "value": "ref"
-        }
-      ]
-    },
-    "value_type": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "type"
-        },
-        {
-          "type": "STRING",
-          "value": "val"
-        }
-      ]
-    },
-    "box_type": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "type"
-        },
-        {
-          "type": "STRING",
-          "value": "box"
-        }
-      ]
-    },
-    "tag_type": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "type"
-        },
-        {
-          "type": "STRING",
-          "value": "tag"
         }
       ]
     },
@@ -1922,37 +2016,9 @@
         ]
       }
     },
-    "lambda_type": {
+    "lambda_parameters": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "@"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "capability"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
         {
           "type": "STRING",
           "value": "("
@@ -1993,6 +2059,72 @@
         {
           "type": "STRING",
           "value": ")"
+        }
+      ]
+    },
+    "lambda_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "@"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "capability"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "generic_parameters"
+              },
+              "named": true,
+              "value": "type_parameters"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lambda_parameters"
         },
         {
           "type": "CHOICE",
@@ -2005,8 +2137,12 @@
                   "value": ":"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "type"
+                  "type": "FIELD",
+                  "name": "returns",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "type"
+                  }
                 }
               ]
             },
@@ -2028,49 +2164,44 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "=>"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "type"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
           "type": "STRING",
           "value": "}"
         }
       ]
     },
-    "member_type": {
-      "type": "PREC_RIGHT",
+    "block": {
+      "type": "PREC_LEFT",
       "value": 0,
       "content": {
         "type": "SEQ",
         "members": [
           {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "expression"
           },
           {
-            "type": "STRING",
-            "value": "."
-          },
-          {
-            "type": "SYMBOL",
-            "name": "type"
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ";"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              ]
+            }
           }
         ]
       }
@@ -2180,7 +2311,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "generic_type"
+          "name": "generic_expression"
         },
         {
           "type": "SYMBOL",
@@ -2200,9 +2331,50 @@
         },
         {
           "type": "SYMBOL",
-          "name": "none"
+          "name": "error"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "compile_intrinsic"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "compile_error"
         }
       ]
+    },
+    "error": {
+      "type": "STRING",
+      "value": "error"
+    },
+    "compile_intrinsic": {
+      "type": "STRING",
+      "value": "compile_intrinsic"
+    },
+    "compile_error": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "compile_error"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "string"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "unary_expression": {
       "type": "PREC_LEFT",
@@ -3592,8 +3764,30 @@
         ]
       }
     },
+    "generic_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "ffi_identifier"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_args"
+        }
+      ]
+    },
     "assignment_expression": {
-      "type": "PREC_RIGHT",
+      "type": "PREC_LEFT",
       "value": 1,
       "content": {
         "type": "SEQ",
@@ -3608,19 +3802,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "expression"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ";"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "name": "block"
           }
         ]
       }
@@ -3766,18 +3948,6 @@
               {
                 "type": "STRING",
                 "value": "?"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ";"
               },
               {
                 "type": "BLANK"
@@ -3977,28 +4147,8 @@
           "value": "=>"
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "expression"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ";"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              }
-            ]
-          }
+          "type": "SYMBOL",
+          "name": "block"
         },
         {
           "type": "STRING",
@@ -4019,55 +4169,63 @@
       ]
     },
     "lambda_parameter": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ":"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "type"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
+      "type": "PREC",
+      "value": -2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
             }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "="
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "literal"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ":"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "type"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "="
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "lambda_captures": {
       "type": "SEQ",
@@ -4088,6 +4246,27 @@
                     {
                       "type": "SYMBOL",
                       "name": "identifier"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ":"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "type"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
                     },
                     {
                       "type": "CHOICE",
@@ -4127,6 +4306,27 @@
                           {
                             "type": "SYMBOL",
                             "name": "identifier"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": ":"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "type"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
                           },
                           {
                             "type": "CHOICE",
@@ -4317,7 +4517,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "expression"
+          "name": "block"
         }
       ]
     },
@@ -4341,11 +4541,8 @@
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
+          "type": "SYMBOL",
+          "name": "block"
         }
       ]
     },
@@ -4370,7 +4567,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "expression"
+          "name": "block"
         },
         {
           "type": "SYMBOL",
@@ -4488,11 +4685,8 @@
           ]
         },
         {
-          "type": "REPEAT1",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
+          "type": "SYMBOL",
+          "name": "block"
         }
       ]
     },
@@ -4586,28 +4780,8 @@
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "expression"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ";"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              }
-            ]
-          }
+          "type": "SYMBOL",
+          "name": "block"
         },
         {
           "type": "CHOICE",
@@ -4639,6 +4813,23 @@
         }
       ]
     },
+    "with_elem": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block"
+        }
+      ]
+    },
     "with_statement": {
       "type": "SEQ",
       "members": [
@@ -4647,8 +4838,41 @@
           "value": "with"
         },
         {
-          "type": "SYMBOL",
-          "name": "expression"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "annotation"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "with_elem"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "with_elem"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -4676,11 +4900,8 @@
           ]
         },
         {
-          "type": "REPEAT1",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
+          "type": "SYMBOL",
+          "name": "block"
         },
         {
           "type": "STRING",
@@ -4728,11 +4949,8 @@
           "value": "do"
         },
         {
-          "type": "REPEAT1",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
+          "type": "SYMBOL",
+          "name": "block"
         },
         {
           "type": "CHOICE",
@@ -4784,11 +5002,8 @@
           ]
         },
         {
-          "type": "REPEAT1",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
+          "type": "SYMBOL",
+          "name": "block"
         },
         {
           "type": "STRING",
@@ -4817,7 +5032,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "expression"
+          "name": "block"
         },
         {
           "type": "REPEAT1",
@@ -4919,42 +5134,85 @@
           "value": "=>"
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "expression"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ";"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              }
-            ]
-          }
+          "type": "SYMBOL",
+          "name": "block"
         }
       ]
     },
     "return_statement": {
-      "type": "STRING",
-      "value": "return"
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "return"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "block"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "continue_statement": {
-      "type": "STRING",
-      "value": "continue"
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "continue"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "block"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "break_statement": {
-      "type": "STRING",
-      "value": "break"
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "break"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "block"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "consume_expression": {
       "type": "SEQ",
@@ -4964,8 +5222,75 @@
           "value": "consume"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "capability"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "identifier"
+        }
+      ]
+    },
+    "generic_parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ":"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "type"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "FIELD",
+                  "name": "default",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "type"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -4980,55 +5305,8 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "type"
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ":"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "type"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "="
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "type"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "generic_parameter"
             },
             {
               "type": "REPEAT",
@@ -5040,55 +5318,8 @@
                     "value": ","
                   },
                   {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "type"
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": ":"
-                              },
-                              {
-                                "type": "SYMBOL",
-                                "name": "type"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "="
-                              },
-                              {
-                                "type": "SYMBOL",
-                                "name": "type"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "generic_parameter"
                   }
                 ]
               }
@@ -5170,62 +5401,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ";"
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "as"
-                              },
-                              {
-                                "type": "SYMBOL",
-                                "name": "type"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": ":"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "expression"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "block"
             },
             {
               "type": "BLANK"
@@ -5412,25 +5589,58 @@
       ]
     },
     "_multiline_string_literal": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "\"\"\""
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_multiline_string_content"
+                  },
+                  "named": true,
+                  "value": "string_content"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_escape_sequence"
+                }
+              ]
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "\"\"\""
+          }
+        ]
+      }
+    },
+    "character": {
       "type": "SEQ",
       "members": [
         {
           "type": "STRING",
-          "value": "\"\"\""
+          "value": "'"
         },
         {
-          "type": "REPEAT",
+          "type": "REPEAT1",
           "content": {
             "type": "CHOICE",
             "members": [
               {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_multiline_string_content"
-                },
-                "named": true,
-                "value": "string_content"
+                "type": "SYMBOL",
+                "name": "character_content"
               },
               {
                 "type": "SYMBOL",
@@ -5441,42 +5651,20 @@
         },
         {
           "type": "STRING",
-          "value": "\"\"\""
+          "value": "'"
         }
       ]
     },
-    "character": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "'"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
-                "type": "PREC",
-                "value": 2,
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[^'\\\\]"
-                }
-              }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_escape_sequence"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "'"
+    "character_content": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": 2,
+        "content": {
+          "type": "PATTERN",
+          "value": "[^'\\\\]+"
         }
-      ]
+      }
     },
     "string_content": {
       "type": "IMMEDIATE_TOKEN",
@@ -5639,10 +5827,6 @@
       "type": "STRING",
       "value": "this"
     },
-    "none": {
-      "type": "STRING",
-      "value": "None"
-    },
     "comment": {
       "type": "TOKEN",
       "content": {
@@ -5695,7 +5879,7 @@
   "conflicts": [
     [
       "expression",
-      "generic_type"
+      "generic_expression"
     ]
   ],
   "precedences": [],
@@ -5714,7 +5898,9 @@
     "CAST": 3,
     "UNARY": 4,
     "CALL": 5,
-    "MEMBER": 6
+    "MEMBER": 6,
+    "TYPEARGS": 7,
+    "ARRAY_LITERAL": 8
   }
 }
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5514,6 +5514,10 @@
                 }
               }
             ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_string_literal"
           }
         ]
       }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -28,11 +28,23 @@
         "named": true
       },
       {
+        "type": "compile_error",
+        "named": true
+      },
+      {
+        "type": "compile_intrinsic",
+        "named": true
+      },
+      {
         "type": "consume_expression",
         "named": true
       },
       {
         "type": "continue_statement",
+        "named": true
+      },
+      {
+        "type": "error",
         "named": true
       },
       {
@@ -44,7 +56,7 @@
         "named": true
       },
       {
-        "type": "generic_type",
+        "type": "generic_expression",
         "named": true
       },
       {
@@ -73,10 +85,6 @@
       },
       {
         "type": "member_expression",
-        "named": true
-      },
-      {
-        "type": "none",
         "named": true
       },
       {
@@ -172,7 +180,15 @@
     "named": true,
     "subtypes": [
       {
+        "type": "alias_type",
+        "named": true
+      },
+      {
         "type": "aliased_type",
+        "named": true
+      },
+      {
+        "type": "any_type",
         "named": true
       },
       {
@@ -188,15 +204,11 @@
         "named": true
       },
       {
-        "type": "generic_type",
-        "named": true
-      },
-      {
         "type": "intersection_type",
         "named": true
       },
       {
-        "type": "isolated_type",
+        "type": "iso_type",
         "named": true
       },
       {
@@ -204,15 +216,19 @@
         "named": true
       },
       {
-        "type": "member_type",
+        "type": "read_type",
         "named": true
       },
       {
-        "type": "none",
+        "type": "ref_type",
         "named": true
       },
       {
-        "type": "reference_type",
+        "type": "send_type",
+        "named": true
+      },
+      {
+        "type": "share_type",
         "named": true
       },
       {
@@ -224,7 +240,7 @@
         "named": true
       },
       {
-        "type": "transition_type",
+        "type": "trn_type",
         "named": true
       },
       {
@@ -236,7 +252,7 @@
         "named": true
       },
       {
-        "type": "value_type",
+        "type": "val_type",
         "named": true
       },
       {
@@ -293,6 +309,25 @@
     }
   },
   {
+    "type": "alias_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "base_type",
+          "named": true
+        },
+        {
+          "type": "lambda_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "aliased_type",
     "named": true,
     "fields": {},
@@ -323,6 +358,25 @@
     }
   },
   {
+    "type": "any_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "base_type",
+          "named": true
+        },
+        {
+          "type": "lambda_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "array_literal",
     "named": true,
     "fields": {},
@@ -331,7 +385,7 @@
       "required": false,
       "types": [
         {
-          "type": "expression",
+          "type": "block",
           "named": true
         },
         {
@@ -350,6 +404,10 @@
       "required": true,
       "types": [
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         }
@@ -359,17 +417,28 @@
   {
     "type": "base_type",
     "named": true,
-    "fields": {},
+    "fields": {
+      "name": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": ".",
+            "named": false
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
         {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "type_capability",
+          "type": "type_args",
           "named": true
         }
       ]
@@ -388,15 +457,19 @@
           "named": true
         },
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "capability",
           "named": true
         },
         {
-          "type": "expression",
+          "type": "generic_parameters",
           "named": true
         },
         {
-          "type": "generic_parameters",
+          "type": "identifier",
           "named": true
         },
         {
@@ -599,6 +672,21 @@
     }
   },
   {
+    "type": "block",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "boolean",
     "named": true,
     "fields": {}
@@ -612,7 +700,26 @@
       "required": true,
       "types": [
         {
-          "type": "type",
+          "type": "base_type",
+          "named": true
+        },
+        {
+          "type": "lambda_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "break_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "block",
           "named": true
         }
       ]
@@ -666,6 +773,10 @@
           "named": true
         },
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         },
@@ -715,9 +826,13 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "character_content",
+          "named": true
+        },
         {
           "type": "escape_sequence",
           "named": true
@@ -777,6 +892,21 @@
     }
   },
   {
+    "type": "compile_error",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "constructor",
     "named": true,
     "fields": {},
@@ -789,15 +919,19 @@
           "named": true
         },
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "capability",
           "named": true
         },
         {
-          "type": "expression",
+          "type": "generic_parameters",
           "named": true
         },
         {
-          "type": "generic_parameters",
+          "type": "identifier",
           "named": true
         },
         {
@@ -816,11 +950,30 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
+          "type": "capability",
+          "named": true
+        },
+        {
           "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "continue_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "block",
           "named": true
         }
       ]
@@ -835,11 +988,11 @@
       "required": true,
       "types": [
         {
-          "type": "else_block",
+          "type": "block",
           "named": true
         },
         {
-          "type": "expression",
+          "type": "else_block",
           "named": true
         }
       ]
@@ -858,7 +1011,7 @@
           "named": true
         },
         {
-          "type": "expression",
+          "type": "block",
           "named": true
         }
       ]
@@ -877,7 +1030,7 @@
           "named": true
         },
         {
-          "type": "expression",
+          "type": "block",
           "named": true
         },
         {
@@ -989,7 +1142,18 @@
   {
     "type": "field",
     "named": true,
-    "fields": {},
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -1044,22 +1208,7 @@
     }
   },
   {
-    "type": "generic_parameters",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "type",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "generic_type",
+    "type": "generic_expression",
     "named": true,
     "fields": {},
     "children": {
@@ -1075,11 +1224,52 @@
           "named": true
         },
         {
-          "type": "type",
+          "type": "type_args",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "generic_parameter",
+    "named": true,
+    "fields": {
+      "default": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
           "named": true
         },
         {
-          "type": "type_capability",
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "generic_parameters",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "generic_parameter",
           "named": true
         }
       ]
@@ -1098,7 +1288,7 @@
           "named": true
         },
         {
-          "type": "expression",
+          "type": "block",
           "named": true
         }
       ]
@@ -1221,7 +1411,7 @@
     }
   },
   {
-    "type": "isolated_type",
+    "type": "iso_type",
     "named": true,
     "fields": {},
     "children": {
@@ -1229,7 +1419,11 @@
       "required": true,
       "types": [
         {
-          "type": "type",
+          "type": "base_type",
+          "named": true
+        },
+        {
+          "type": "lambda_type",
           "named": true
         }
       ]
@@ -1246,6 +1440,10 @@
         {
           "type": "expression",
           "named": true
+        },
+        {
+          "type": "type",
+          "named": true
         }
       ]
     }
@@ -1256,14 +1454,14 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
-          "type": "capability",
+          "type": "block",
           "named": true
         },
         {
-          "type": "expression",
+          "type": "capability",
           "named": true
         },
         {
@@ -1284,17 +1482,24 @@
   {
     "type": "lambda_parameter",
     "named": true,
-    "fields": {},
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "literal",
+          "type": "expression",
           "named": true
         },
         {
@@ -1305,7 +1510,7 @@
     }
   },
   {
-    "type": "lambda_type",
+    "type": "lambda_parameters",
     "named": true,
     "fields": {},
     "children": {
@@ -1313,11 +1518,45 @@
       "required": false,
       "types": [
         {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "lambda_type",
+    "named": true,
+    "fields": {
+      "returns": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
           "type": "capability",
           "named": true
         },
         {
-          "type": "type",
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "lambda_parameters",
+          "named": true
+        },
+        {
+          "type": "type_parameters",
           "named": true
         }
       ]
@@ -1375,15 +1614,15 @@
           "named": true
         },
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "case_statement",
           "named": true
         },
         {
           "type": "else_block",
-          "named": true
-        },
-        {
-          "type": "expression",
           "named": true
         }
       ]
@@ -1399,25 +1638,6 @@
       "types": [
         {
           "type": "expression",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "member_type",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "type",
           "named": true
         }
       ]
@@ -1447,15 +1667,19 @@
           "named": true
         },
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "capability",
           "named": true
         },
         {
-          "type": "expression",
+          "type": "generic_parameters",
           "named": true
         },
         {
-          "type": "generic_parameters",
+          "type": "identifier",
           "named": true
         },
         {
@@ -1518,7 +1742,18 @@
   {
     "type": "parameter",
     "named": true,
-    "fields": {},
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": false,
@@ -1634,6 +1869,25 @@
     }
   },
   {
+    "type": "read_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "base_type",
+          "named": true
+        },
+        {
+          "type": "lambda_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "recover_expression",
     "named": true,
     "fields": {},
@@ -1646,18 +1900,18 @@
           "named": true
         },
         {
-          "type": "capability",
+          "type": "block",
           "named": true
         },
         {
-          "type": "expression",
+          "type": "capability",
           "named": true
         }
       ]
     }
   },
   {
-    "type": "reference_type",
+    "type": "ref_type",
     "named": true,
     "fields": {},
     "children": {
@@ -1665,7 +1919,11 @@
       "required": true,
       "types": [
         {
-          "type": "type",
+          "type": "base_type",
+          "named": true
+        },
+        {
+          "type": "lambda_type",
           "named": true
         }
       ]
@@ -1684,11 +1942,68 @@
           "named": true
         },
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "else_block",
           "named": true
         },
         {
           "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "return_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "block",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "send_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "base_type",
+          "named": true
+        },
+        {
+          "type": "lambda_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "share_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "base_type",
+          "named": true
+        },
+        {
+          "type": "lambda_type",
           "named": true
         }
       ]
@@ -1803,7 +2118,11 @@
       "required": true,
       "types": [
         {
-          "type": "type",
+          "type": "base_type",
+          "named": true
+        },
+        {
+          "type": "lambda_type",
           "named": true
         }
       ]
@@ -1815,14 +2134,14 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "annotation",
           "named": true
         },
         {
-          "type": "expression",
+          "type": "block",
           "named": true
         }
       ]
@@ -1876,7 +2195,7 @@
     }
   },
   {
-    "type": "transition_type",
+    "type": "trn_type",
     "named": true,
     "fields": {},
     "children": {
@@ -1884,7 +2203,11 @@
       "required": true,
       "types": [
         {
-          "type": "type",
+          "type": "base_type",
+          "named": true
+        },
+        {
+          "type": "lambda_type",
           "named": true
         }
       ]
@@ -1896,18 +2219,18 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "annotation",
           "named": true
         },
         {
-          "type": "else_block",
+          "type": "block",
           "named": true
         },
         {
-          "type": "expression",
+          "type": "else_block",
           "named": true
         },
         {
@@ -1975,9 +2298,19 @@
     }
   },
   {
-    "type": "type_capability",
+    "type": "type_args",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "type_parameters",
@@ -1988,7 +2321,7 @@
       "required": true,
       "types": [
         {
-          "type": "type",
+          "type": "generic_parameter",
           "named": true
         }
       ]
@@ -2079,7 +2412,7 @@
     }
   },
   {
-    "type": "value_type",
+    "type": "val_type",
     "named": true,
     "fields": {},
     "children": {
@@ -2087,7 +2420,11 @@
       "required": true,
       "types": [
         {
-          "type": "type",
+          "type": "base_type",
+          "named": true
+        },
+        {
+          "type": "lambda_type",
           "named": true
         }
       ]
@@ -2151,6 +2488,25 @@
     }
   },
   {
+    "type": "with_elem",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "with_statement",
     "named": true,
     "fields": {},
@@ -2159,11 +2515,15 @@
       "required": true,
       "types": [
         {
+          "type": "annotation",
+          "named": true
+        },
+        {
           "type": "do_block",
           "named": true
         },
         {
-          "type": "expression",
+          "type": "with_elem",
           "named": true
         }
       ]
@@ -2442,7 +2802,11 @@
     "named": false
   },
   {
-    "type": "break_statement",
+    "type": "break",
+    "named": false
+  },
+  {
+    "type": "character_content",
     "named": true
   },
   {
@@ -2454,12 +2818,20 @@
     "named": true
   },
   {
+    "type": "compile_error",
+    "named": false
+  },
+  {
+    "type": "compile_intrinsic",
+    "named": true
+  },
+  {
     "type": "consume",
     "named": false
   },
   {
-    "type": "continue_statement",
-    "named": true
+    "type": "continue",
+    "named": false
   },
   {
     "type": "digestof",
@@ -2484,6 +2856,10 @@
   {
     "type": "end",
     "named": false
+  },
+  {
+    "type": "error",
+    "named": true
   },
   {
     "type": "escape_sequence",
@@ -2554,10 +2930,6 @@
     "named": false
   },
   {
-    "type": "none",
-    "named": true
-  },
-  {
     "type": "not",
     "named": false
   },
@@ -2590,8 +2962,8 @@
     "named": false
   },
   {
-    "type": "return_statement",
-    "named": true
+    "type": "return",
+    "named": false
   },
   {
     "type": "struct",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1735,7 +1735,21 @@
   {
     "type": "string_content",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "string_content",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "struct_definition",

--- a/test/corpus/characters.txt
+++ b/test/corpus/characters.txt
@@ -1,0 +1,69 @@
+=================
+Character Literal
+=================
+
+use "snot" if 'A'
+
+---
+(source_file
+  (use_statement
+    (string (string_content))
+    (platform_specifier
+      (if_block
+        (block
+          (literal (character (character_content)))
+        )
+      )
+    )
+  )
+)
+
+=================
+Character Escapes
+=================
+
+use "snot" if '\xFF\''
+---
+(source_file
+  (use_statement
+    (string (string_content))
+    (platform_specifier
+      (if_block
+        (block
+          (literal 
+            (character
+              (escape_sequence)
+              (escape_sequence)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+====================
+Multibyte Characters
+====================
+
+use "snot" if 'A\nBCDEFGH'
+---
+(source_file
+  (use_statement
+    (string (string_content))
+    (platform_specifier
+      (if_block
+        (block
+          (literal
+            (character
+              (character_content)
+              (escape_sequence)
+              (character_content)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/test/corpus/entity.txt
+++ b/test/corpus/entity.txt
@@ -34,26 +34,28 @@ actor Main
   (string (string_content))
   (actor_definition
     (identifier) 
-    (string (string_content))
+    docstring: (string (string_content))
     (field
-      (identifier)
-      (base_type (identifier))
-      (string (string_content))
+      name: (identifier)
+      (base_type name: (identifier))
+      docstring: (string (string_content))
     )
     (field
-      (identifier)
-      (reference_type
-        (base_type (identifier)))
+      name: (identifier)
+      (ref_type
+        (base_type name: (identifier)))
       (literal (string (string_content)))
-      (string (string_content))
+      docstring: (string (string_content))
     )
     (field
-      (identifier)
+      name: (identifier)
       (intersection_type
-        (base_type (identifier))
-        (generic_type
-          (identifier)
-          (base_type (identifier))
+        (base_type name: (identifier))
+        (base_type
+          name: (identifier)
+          (type_args
+            (base_type name: (identifier))
+          )
         )
       )
     )
@@ -62,8 +64,8 @@ actor Main
       (identifier)
       (parameters
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
         )
       )
       (block
@@ -74,13 +76,15 @@ actor Main
     (behavior
       (identifier)
       (generic_parameters
-        (base_type (identifier))
-        (base_type (identifier))
+        (generic_parameter
+          (identifier)
+          (base_type name: (identifier))
+        )
       )
       (parameters
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
         )
       )
       (block
@@ -111,14 +115,14 @@ actor Main
     (string (string_content))
     (platform_specifier (if_block (block (identifier))))
   )
-  (actor_definition 
+  (actor_definition
     (identifier)
     (constructor
       (identifier)
       (parameters
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
         )
       )
       (block
@@ -141,7 +145,7 @@ actor Main
       (capability)
       (identifier)
       (parameters)
-      returns: (base_type (identifier))
+      returns: (base_type name: (identifier))
       (block
         (literal (boolean))
       )
@@ -149,15 +153,19 @@ actor Main
     (behavior
       (identifier)
       (generic_parameters
-        (base_type (identifier))
-        (base_type (identifier))
+        (generic_parameter
+          (identifier)
+          (base_type name: (identifier))
+        )
       )
       (parameters
         (parameter
-          (identifier)
-          (generic_type
-            (identifier)
-            (base_type (identifier))
+          name: (identifier)
+          (base_type
+            name: (identifier)
+            (type_args
+              (base_type name: (identifier))
+            )
           )
         )
       )
@@ -198,30 +206,32 @@ class MT is Random
 (source_file
   (class_definition
     (identifier)
-    (base_type (identifier))
+    (base_type name: (identifier))
     (string (string_content))
     (field
-      (identifier)
-      (generic_type
-        (identifier)
-        (base_type (identifier))
+      name: (identifier)
+      (base_type
+        name: (identifier)
+        (type_args
+          (base_type name: (identifier))
+        )
       )
     )
     (field
-      (identifier)
-      (base_type (identifier))
+      name: (identifier)
+      (base_type name: (identifier))
     )
     (constructor
       (identifier)
       (parameters
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
           (literal (number))
         )
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
           (literal (number))
         )
       )
@@ -231,9 +241,11 @@ class MT is Random
           (identifier)
           (block
             (call_expression
-              callee: (generic_type
+              callee: (generic_expression
                 (identifier)
-                (base_type (identifier))
+                (type_args
+                  (base_type name: (identifier))
+                )
               )
               (call_expression
                 callee: (identifier)
@@ -276,19 +288,19 @@ interface Notify
       (identifier)
       (parameters
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
         )
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
         )
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
         ) 
       )
-      returns: (base_type (identifier))
+      returns: (base_type name: (identifier))
       (string (string_content))
     )
   )
@@ -305,6 +317,6 @@ actor \nodoc,test\ Main is TestList
   (actor_definition
     (annotation (identifier) (identifier))
     (identifier)
-    (base_type (identifier))
+    (base_type name: (identifier))
   )
 )

--- a/test/corpus/entity.txt
+++ b/test/corpus/entity.txt
@@ -1,0 +1,310 @@
+==========
+Docstrings
+==========
+
+"""
+module docstring
+"""
+
+actor Main
+  """
+  actor docstring
+  """
+
+  let x: U8
+    "field docstring"
+  var y: String ref = "default"
+    """
+    long field docstring of field with default value
+    """
+  embed z: (U8 & Real[U8])
+
+  new ref create(env: Env) =>
+    """
+    constructor docstring
+    """
+    consume env
+
+  be with_param[Type: Constraint](arg: Type) =>
+    "snot"
+
+---
+
+(source_file 
+  (string (string_content))
+  (actor_definition
+    (identifier) 
+    (string (string_content))
+    (field
+      (identifier)
+      (base_type (identifier))
+      (string (string_content))
+    )
+    (field
+      (identifier)
+      (reference_type
+        (base_type (identifier)))
+      (literal (string (string_content)))
+      (string (string_content))
+    )
+    (field
+      (identifier)
+      (intersection_type
+        (base_type (identifier))
+        (generic_type
+          (identifier)
+          (base_type (identifier))
+        )
+      )
+    )
+    (constructor
+      (capability)
+      (identifier)
+      (parameters
+        (parameter
+          (identifier)
+          (base_type (identifier))
+        )
+      )
+      (block
+        (literal (string (string_content)))
+        (consume_expression (identifier))
+      )
+    )
+    (behavior
+      (identifier)
+      (generic_parameters
+        (base_type (identifier))
+        (base_type (identifier))
+      )
+      (parameters
+        (parameter
+          (identifier)
+          (base_type (identifier))
+        )
+      )
+      (block
+        (literal (string (string_content)))
+      )
+    )
+  )
+)
+
+=============
+Method quirks
+=============
+
+use "collection" if windows
+
+actor Main
+  new create(env: Env) =>
+    env.out.print("awesome" * 2)
+
+  fun ref awesome(): Bool => true
+
+  be yeah[Arg: Constraint](foo: Array[U8]) =>
+    foo~partial(56.7)
+
+---
+(source_file
+  (use_statement
+    (string (string_content))
+    (platform_specifier (if_block (block (identifier))))
+  )
+  (actor_definition 
+    (identifier)
+    (constructor
+      (identifier)
+      (parameters
+        (parameter
+          (identifier)
+          (base_type (identifier))
+        )
+      )
+      (block
+        (call_expression
+          callee: (member_expression
+            (identifier)
+            (member_expression
+              (identifier)
+              (identifier)
+            )
+          )
+          (binary_expression
+            left: (literal (string (string_content)))
+            right: (literal (number))
+          )
+        )
+      )
+    )
+    (method
+      (capability)
+      (identifier)
+      (parameters)
+      returns: (base_type (identifier))
+      (block
+        (literal (boolean))
+      )
+    )
+    (behavior
+      (identifier)
+      (generic_parameters
+        (base_type (identifier))
+        (base_type (identifier))
+      )
+      (parameters
+        (parameter
+          (identifier)
+          (generic_type
+            (identifier)
+            (base_type (identifier))
+          )
+        )
+      )
+      (block
+        (call_expression
+          callee: (partial_application
+            (identifier)
+            (identifier)
+          )
+          (literal (float))
+        )
+      )
+    )
+  )
+)
+
+======
+MT
+======
+
+class MT is Random
+  """
+  bla
+  bla
+  bla
+  """
+  embed _state: Array[U64]
+  var _index: USize
+
+  new create(x: U64 = 5489, y: U64 = 0) =>
+    """
+    docstring
+    """
+    _state = Array[U64](_n())
+    _index = _n()
+---
+
+(source_file
+  (class_definition
+    (identifier)
+    (base_type (identifier))
+    (string (string_content))
+    (field
+      (identifier)
+      (generic_type
+        (identifier)
+        (base_type (identifier))
+      )
+    )
+    (field
+      (identifier)
+      (base_type (identifier))
+    )
+    (constructor
+      (identifier)
+      (parameters
+        (parameter
+          (identifier)
+          (base_type (identifier))
+          (literal (number))
+        )
+        (parameter
+          (identifier)
+          (base_type (identifier))
+          (literal (number))
+        )
+      )
+      (block
+        (literal (string (string_content)))
+        (assignment_expression
+          (identifier)
+          (block
+            (call_expression
+              callee: (generic_type
+                (identifier)
+                (base_type (identifier))
+              )
+              (call_expression
+                callee: (identifier)
+              )
+            )
+          )
+        )
+        (assignment_expression
+          (identifier)
+          (block
+            (call_expression
+              callee: (identifier)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=========
+Interface
+=========
+
+interface Notify
+  """
+  Notify
+  """
+  fun ref apply(section: String, key: String, value: String): Bool
+    """
+    docstring
+    """
+---
+(source_file
+  (interface_definition
+    (identifier)
+    (string (string_content))
+    (method
+      (capability)
+      (identifier)
+      (parameters
+        (parameter
+          (identifier)
+          (base_type (identifier))
+        )
+        (parameter
+          (identifier)
+          (base_type (identifier))
+        )
+        (parameter
+          (identifier)
+          (base_type (identifier))
+        ) 
+      )
+      returns: (base_type (identifier))
+      (string (string_content))
+    )
+  )
+)
+
+=========
+Annotated
+=========
+
+actor \nodoc,test\ Main is TestList
+
+---
+(source_file
+  (actor_definition
+    (annotation (identifier) (identifier))
+    (identifier)
+    (base_type (identifier))
+  )
+)

--- a/test/corpus/exprs.txt
+++ b/test/corpus/exprs.txt
@@ -223,9 +223,11 @@ primitive Foo
       (block
         (call_expression
           callee: (member_expression
-            (generic_type
+            (generic_expression
               (identifier)
-              (base_type (identifier))
+              (type_args
+                (base_type name: (identifier))
+              )
             )
             (identifier)
           )
@@ -303,7 +305,9 @@ primitive Foo[A]
   (primitive_definition
     (identifier)
     (generic_parameters
-      (base_type (identifier))
+      (generic_parameter
+        (identifier)
+      )
     )
     (method
       (identifier)
@@ -376,6 +380,83 @@ primitive Snot
                   )
                 )
               )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+
+=============
+Array Literal
+=============
+
+trait iso T
+
+class iso C1 is T
+class iso C2 is T
+
+primitive Foo
+  fun apply(): Array[T] =>
+    let c1: C1 iso = C1
+    let c2: C2 iso = C2
+    [as T: consume c1; consume c2]
+
+---
+
+(source_file
+  (trait_definition
+    (capability)
+    (identifier)
+  )
+  (class_definition
+    (capability)
+    (identifier)
+    (base_type name: (identifier))
+  )
+  (class_definition
+    (capability)
+    (identifier)
+    (base_type name: (identifier))
+  )
+  (primitive_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters)
+      returns: (base_type
+        name: (identifier)
+        (type_args
+          (base_type name: (identifier))
+        )
+      )
+      (block
+        (assignment_expression
+          (variable_declaration
+            (identifier)
+            (iso_type
+              (base_type name: (identifier))
+            )
+          )
+          (block (identifier))
+        )
+        (assignment_expression
+          (variable_declaration
+            (identifier)
+            (iso_type
+              (base_type name: (identifier))
+            )
+          )
+          (block (identifier))
+        )
+        (literal
+          (array_literal
+            (base_type name: (identifier))
+            (block
+              (consume_expression (identifier))
+              (consume_expression (identifier))
             )
           )
         )

--- a/test/corpus/exprs.txt
+++ b/test/corpus/exprs.txt
@@ -1,0 +1,386 @@
+=========
+Unary ops
+=========
+
+use "snot" if not badger
+
+---
+
+(source_file
+  (use_statement
+    (string (string_content))
+    (platform_specifier
+      (if_block
+        (block
+          (unary_expression
+            argument: (identifier)
+          )
+        )
+      )
+    )
+  )
+)
+
+==============
+Array Literals
+==============
+
+use "snot" if [
+  []
+  [
+    1
+    2
+    3
+  ]
+]
+
+---
+(source_file
+  (use_statement
+    (string (string_content))
+    (platform_specifier
+      (if_block
+        (block
+          (literal
+            (array_literal
+              (block
+                (literal (array_literal))
+                (literal
+                  (array_literal
+                    (block
+                      (literal (number))
+                      (literal (number))
+                      (literal (number))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=======================
+Array Literals In Block
+=======================
+
+primitive Snot
+  fun foo() =>
+    []
+    []
+
+---
+
+(source_file
+  (primitive_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters)
+      (block
+        (literal
+          (array_literal))
+        (literal
+          (array_literal))
+      )
+    )
+  )
+)
+
+=======================
+Strings In Block
+=======================
+
+primitive Snot
+  fun foo() =>
+    "foo"
+    "bar"
+
+---
+
+(source_file
+  (primitive_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters)
+      (block
+        (literal (string (string_content)))
+        (literal (string (string_content)))
+      )
+    )
+  )
+)
+
+===================
+Empty Array Literal
+===================
+
+use "" if []
+
+---
+(source_file
+  (use_statement
+    (string)
+    (platform_specifier
+      (if_block 
+        (block
+          (literal (array_literal))
+        )
+      )
+    )
+  )
+)
+
+===============
+Array Type Hint
+===============
+
+use "" if [as U8:
+  13
+  12
+]
+---
+(source_file
+  (use_statement
+    (string)
+    (platform_specifier
+      (if_block
+        (block
+          (literal 
+            (array_literal
+              (base_type (identifier))
+              (block
+                (literal (number))
+                (literal (number))
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+========
+If Block
+========
+
+primitive Foo
+  fun bar() =>
+    if "first_line"
+       true
+    then
+      "then"
+    end
+---
+
+(source_file
+  (primitive_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters)
+      (block
+        (if_statement
+          (if_block
+            (block
+              (literal (string (string_content)))
+              (literal (boolean))
+            )
+          )
+          (then_block
+            (block
+              (literal (string (string_content)))
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+================================
+Partial Application in Arguments
+================================
+
+primitive Foo
+  fun foo() =>
+    Promises[A].join(
+      [this]
+        .> concat(ps)
+        .values())
+---
+(source_file
+  (primitive_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters)
+      (block
+        (call_expression
+          callee: (member_expression
+            (generic_type
+              (identifier)
+              (base_type (identifier))
+            )
+            (identifier)
+          )
+          (call_expression
+            callee: (member_expression
+              (call_expression
+                callee: (chain_expression
+                  (literal
+                    (array_literal (block (this)))
+                  )
+                  (identifier)
+                )
+                (identifier)
+              )
+            (identifier)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+Block with ffi call
+===================
+
+primitive Foo
+  fun bar() =>
+    let f = Foo.bar()
+    @baz("argument")
+---
+(source_file
+  (primitive_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters)
+      (block
+        (assignment_expression
+          (variable_declaration (identifier))
+          (block
+            (call_expression
+              callee: (member_expression
+                (identifier)
+                (identifier)
+              )
+            )
+          )
+        )
+        (call_expression
+          callee: (ffi_identifier (identifier))
+          (literal (string (string_content)))
+        )
+      )
+    )
+  )
+)
+
+======
+Iftype
+======
+
+primitive Foo[A]
+  fun bar() =>
+    iftype A <: Stringable then
+        "snot"
+    elseif A <: Hashable then
+        "hash"
+    else
+        "bla"
+    end
+---
+(source_file
+  (primitive_definition
+    (identifier)
+    (generic_parameters
+      (base_type (identifier))
+    )
+    (method
+      (identifier)
+      (parameters)
+      (block
+        (iftype_statement
+          (base_type (identifier))
+          (base_type (identifier))
+          (then_block
+            (block (literal (string (string_content))))
+          )
+          (elseiftype_block
+            (base_type (identifier))
+            (base_type (identifier))
+            (then_block
+              (block (literal (string (string_content))))
+            )
+          )
+          (else_block
+            (block (literal (string (string_content))))
+          )
+        )
+      )
+    )
+  )
+)
+
+========
+For Loop
+========
+
+primitive Snot
+  fun bar() =>
+    for a in [].values() do
+        while true do
+            repeat
+                None
+            until a == true end
+        end
+    end
+---
+(source_file
+  (primitive_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters)
+      (block
+        (for_statement
+          (identifier)
+          collection: (call_expression
+            callee: (member_expression
+              (literal (array_literal))
+              (identifier)
+            )
+          )
+          (do_block
+            (block
+              (while_statement
+                (literal (boolean))
+                (do_block
+                  (block
+                    (repeat_statement
+                      (block (none))
+                      (binary_expression
+                        left: (identifier)
+                        right: (literal (boolean))
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/test/corpus/exprs.txt
+++ b/test/corpus/exprs.txt
@@ -371,7 +371,7 @@ primitive Snot
                 (do_block
                   (block
                     (repeat_statement
-                      (block (none))
+                      (block (identifier))
                       (binary_expression
                         left: (identifier)
                         right: (literal (boolean))

--- a/test/corpus/lambda.txt
+++ b/test/corpus/lambda.txt
@@ -1,0 +1,242 @@
+===========
+Lambda Type
+===========
+
+primitive Lambda
+  fun lambda(callback: {box function_name[T](Argument[T]): ReturnType? } iso): ReturnType? =>
+    callback.function_name[U8](Argument[U8])?
+---
+
+(source_file
+  (primitive_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters
+        (parameter
+          (identifier)
+          (isolated_type
+            (lambda_type
+              (capability)
+              (identifier)
+              (type_parameters
+                (base_type (identifier))
+              )
+              (generic_type 
+                (identifier)
+                (base_type (identifier))
+              )
+              (base_type (identifier))
+            )
+          )
+        )
+      )
+      returns: (base_type (identifier))
+      (block
+        (call_expression
+          callee: (member_expression
+            (identifier)
+            (generic_type
+              (identifier)
+              (base_type (identifier))
+            )
+          )
+          (generic_type
+            (identifier)
+            (base_type (identifier))
+          )
+        )
+      )
+    )
+  )
+)
+
+======
+Lambda
+======
+
+class Lambda
+  let lambda: {(String): USize} = {(s) => s.size()}
+
+---
+
+(source_file
+  (class_definition
+    (identifier)
+    (field
+      (identifier)
+      (lambda_type
+        (base_type (identifier))
+        (base_type (identifier))
+      )
+      (lambda_expression
+        (lambda_parameter (identifier))
+        (block
+          (call_expression
+            callee: (member_expression
+              (identifier)
+              (identifier)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+========
+No Args
+========
+
+class Lambda
+  let throw_fn: {ref ()} = {() => None } ref
+---
+
+(source_file
+  (class_definition
+    (identifier)
+    (field
+      (identifier)
+      (lambda_type
+        (capability))
+      (lambda_expression
+        (block (none))
+        (capability)
+      )
+    )
+  )
+)
+
+===============
+Lambda Captures
+===============
+
+class Captures
+  fun cap() =>
+    let f = true
+    let l = { ()(f_capture: Bool = f) => not f_capture }
+
+---
+
+(source_file
+  (class_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters)
+      (block
+        (assignment_expression
+          (variable_declaration
+            (identifier)
+          )
+          (block
+            (literal (boolean))
+          )
+        )
+        (assignment_expression
+          (variable_declaration
+            (identifier)
+          )
+          (block
+            (lambda_expression
+              (lambda_captures 
+                (identifier)
+                (base_type (identifier))
+                (identifier)
+              )
+              (block
+                (unary_expression (identifier))
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+==============
+Object Literal
+==============
+
+primitive ObjectLiteral
+  fun bla() =>
+    var obj = object
+      fun baz(): Type ? =>
+        (Body .> chain()).call()
+      be snot[T: Stringable #read](arg: Array[Type] iso^) =>
+        arg.size()
+    end
+
+---
+
+(source_file
+  (primitive_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters)
+      (block
+        (assignment_expression
+          (variable_declaration
+            (identifier)
+          )
+          (block
+            (literal
+              (object_literal
+                (method
+                  (identifier)
+                  (parameters)
+                  (base_type (identifier))
+                  (block
+                    (call_expression
+                      (member_expression
+                        (parenthesized_expression
+                          (call_expression
+                            (chain_expression
+                              (identifier)
+                              (identifier)
+                            )
+                          )
+                        )
+                        (identifier)
+                      )
+                    )
+                  )
+                )
+                (behavior
+                  (identifier)
+                  (generic_parameters
+                    (base_type (identifier))
+                    (base_type (identifier) (type_capability))
+                  )
+                  (parameters
+                    (parameter
+                      (identifier)
+                      (ephemeral_type
+                        (isolated_type
+                          (generic_type
+                            (identifier)
+                            (base_type (identifier))
+                          )
+                        )
+                      )
+                    )
+                  )
+                  (block
+                    (call_expression
+                      (member_expression
+                        (identifier)
+                        (identifier)
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/test/corpus/lambda.txt
+++ b/test/corpus/lambda.txt
@@ -112,7 +112,7 @@ class Lambda
         (lambda_parameters)
       )
       (lambda_expression
-        (block (none))
+        (block (identifier))
         (capability)
       )
     )

--- a/test/corpus/lambda.txt
+++ b/test/corpus/lambda.txt
@@ -14,36 +14,44 @@ primitive Lambda
       (identifier)
       (parameters
         (parameter
-          (identifier)
-          (isolated_type
+          name: (identifier)
+          (iso_type
             (lambda_type
               (capability)
               (identifier)
               (type_parameters
-                (base_type (identifier))
+                (generic_parameter (identifier))
               )
-              (generic_type 
-                (identifier)
-                (base_type (identifier))
+              (lambda_parameters
+                (base_type
+                  name: (identifier)
+                  (type_args
+                    (base_type name: (identifier))
+                  )
+                )
               )
-              (base_type (identifier))
+              returns: (base_type name: (identifier))
             )
           )
         )
       )
-      returns: (base_type (identifier))
+      returns: (base_type name: (identifier))
       (block
         (call_expression
           callee: (member_expression
             (identifier)
-            (generic_type
+            (generic_expression
               (identifier)
-              (base_type (identifier))
+              (type_args
+                (base_type name: (identifier))
+              )
             )
           )
-          (generic_type
+          (generic_expression
             (identifier)
-            (base_type (identifier))
+            (type_args
+              (base_type name: (identifier))
+            )
           )
         )
       )
@@ -64,13 +72,15 @@ class Lambda
   (class_definition
     (identifier)
     (field
-      (identifier)
+      name: (identifier)
       (lambda_type
-        (base_type (identifier))
-        (base_type (identifier))
+        (lambda_parameters
+          (base_type name: (identifier))
+        )
+        returns: (base_type name: (identifier))
       )
       (lambda_expression
-        (lambda_parameter (identifier))
+        (lambda_parameter name: (identifier))
         (block
           (call_expression
             callee: (member_expression
@@ -98,7 +108,9 @@ class Lambda
     (field
       (identifier)
       (lambda_type
-        (capability))
+        (capability)
+        (lambda_parameters)
+      )
       (lambda_expression
         (block (none))
         (capability)
@@ -207,17 +219,23 @@ primitive ObjectLiteral
                 (behavior
                   (identifier)
                   (generic_parameters
-                    (base_type (identifier))
-                    (base_type (identifier) (type_capability))
+                    (generic_parameter
+                      (identifier)
+                      (read_type
+                        (base_type (identifier))
+                      )
+                    )
                   )
                   (parameters
                     (parameter
                       (identifier)
                       (ephemeral_type
-                        (isolated_type
-                          (generic_type
+                        (iso_type
+                          (base_type
                             (identifier)
-                            (base_type (identifier))
+                            (type_args
+                              (base_type (identifier))
+                            )
                           )
                         )
                       )
@@ -232,6 +250,108 @@ primitive ObjectLiteral
                     )
                   )
                 )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+===========
+Bare Lambda
+===========
+
+use @get_function[@{(U32): U32}](typ: U32)
+
+actor Main
+  new create(env: Env) =>
+    let identity = @get_function(0)
+    let add: @{(U32, U32): U32} = @get_function[@{(U32, U32): U32}](1)
+    let result = add(identity(1), identity(2))
+
+---
+
+(source_file
+  (use_statement
+    (ffi_method
+      (identifier)
+      returns: (lambda_type
+        (lambda_parameters
+          (base_type name: (identifier))
+        )
+        returns: (base_type name: (identifier))
+      )
+      (parameters
+        (parameter
+          name: (identifier)
+          (base_type name: (identifier))
+        )
+      )
+    )
+  )
+  (actor_definition
+    (identifier)
+    (constructor
+      (identifier)
+      (parameters
+        (parameter
+          name: (identifier)
+          (base_type name: (identifier))
+        )
+      )
+      (block
+        (assignment_expression
+          (variable_declaration (identifier))
+          (block
+            (call_expression
+              callee: (ffi_identifier (identifier))
+              (literal (number))
+            )
+          )
+        )
+        (assignment_expression
+          (variable_declaration
+            (identifier)
+            (lambda_type
+              (lambda_parameters
+                (base_type name: (identifier))
+                (base_type name: (identifier))
+              )
+              returns: (base_type name: (identifier))
+            )
+          )
+          (block
+            (call_expression
+              callee: (generic_expression
+                (ffi_identifier (identifier))
+                (type_args
+                  (lambda_type
+                    (lambda_parameters
+                      (base_type name: (identifier))
+                      (base_type name: (identifier))
+                    )
+                    returns: (base_type name: (identifier))
+                  )
+                )
+              )
+              (literal (number))
+            )
+          )
+        )
+        (assignment_expression
+          (variable_declaration (identifier))
+          (block
+            (call_expression
+              callee: (identifier)
+              (call_expression
+                callee: (identifier)
+                (literal (number))
+              )
+              (call_expression
+                callee: (identifier)
+                (literal (number))
               )
             )
           )

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -45,7 +45,7 @@ primitive ContainsWith
               )
             )
             (else_block
-              (block (none))
+              (block (identifier))
             )
           )
         )

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1,0 +1,55 @@
+==============
+With Statement
+==============
+
+primitive ContainsWith
+  fun function() =>
+    with obj = SomeObjectThatNeedsDisposing(), other = SomeOtherDisposableObject() do
+      // use obj
+      obj.call(other)?
+    else
+      None
+    end
+
+---
+
+(source_file
+  (primitive_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters)
+      (block
+        (with_statement
+          (with_elem
+            (identifier)
+            (block
+              (call_expression callee: (identifier))
+            )
+          )
+          (with_elem
+            (identifier)
+            (block
+              (call_expression callee: (identifier))
+            )
+          )
+          (do_block
+            (comment)
+            (block
+              (call_expression
+                callee: (member_expression
+                  (identifier)
+                  (identifier)
+                )
+                (identifier)
+              )
+            )
+            (else_block
+              (block (none))
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/test/corpus/strings.txt
+++ b/test/corpus/strings.txt
@@ -1,0 +1,99 @@
+====================
+Single Quoted String
+====================
+
+"single quoted \" use "
+
+---
+
+(source_file 
+  (string
+    (string_content)
+    (escape_sequence)
+    (string_content)
+  )
+)
+
+===================
+Single empty String
+===================
+
+""
+use ""
+
+---
+
+(source_file
+  (string)
+  (use_statement (string))
+)
+
+=======================
+Single Multiline String
+=======================
+
+"
+multi
+use
+"
+
+---
+
+(source_file 
+  (string (string_content))
+)
+
+===================
+Triple empty String
+===================
+
+""""""
+
+---
+
+(source_file (string))
+
+=========================
+Triple multiline String
+=========================
+
+"""
+multi
+line
+use "foo"
+"""
+
+---
+
+(source_file
+  (string (string_content) (string_content) (string_content))
+)
+
+=========================
+Block Quote Triple String
+=========================
+
+/**
+"""
+"""
+*/
+
+---
+
+(source_file (comment))
+
+================================
+Block Quote before Triple String
+================================
+
+/**/
+"""
+hdfjdf
+"""
+
+---
+
+(source_file 
+  (comment)
+  (string (string_content))
+)

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -1,0 +1,61 @@
+==================
+Generic Capability
+==================
+
+class Array[A]
+  fun iso chop[B: (A & Any #send) = A](split_point: USize): (Array[A] iso^, Array[A] iso^) =>
+    None
+
+---
+
+(source_file
+  (class_definition
+    (identifier)
+    (generic_parameters
+      (generic_parameter (identifier))
+    )
+    (method
+      (capability)
+      (identifier)
+      (generic_parameters
+        (generic_parameter
+          (identifier)
+          (intersection_type
+            (base_type name: (identifier))
+            (send_type (base_type name: (identifier)))
+          )
+          default: (base_type name: (identifier))
+        )
+      )
+      (parameters
+        (parameter
+          name: (identifier)
+          (base_type name: (identifier))
+        )
+      )
+      returns: (tuple_type
+        (ephemeral_type
+          (iso_type
+            (base_type
+              name: (identifier)
+              (type_args
+                (base_type name: (identifier))
+              )
+            )
+          )
+        )
+        (ephemeral_type
+          (iso_type
+            (base_type
+              name: (identifier)
+              (type_args
+                (base_type name: (identifier))
+              )
+            )
+          )
+        )
+      )
+      (block (none))
+    )
+  )
+)

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -55,7 +55,7 @@ class Array[A]
           )
         )
       )
-      (block (none))
+      (block (identifier))
     )
   )
 )

--- a/test/corpus/use.txt
+++ b/test/corpus/use.txt
@@ -59,15 +59,15 @@ use @println[U64](i: U64, u: U64, ...)?
   (use_statement
     (ffi_method
       (identifier)
-      returns: (base_type (identifier))
+      returns: (base_type name: (identifier))
       (parameters
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
         )
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
         )
         (parameter)
       )
@@ -111,35 +111,35 @@ use @primitve_types[Bool](a: U64, b: I128, c: Main ref, d: U8 iso^, e: I8 tag!)
   (use_statement
     (ffi_method
       (identifier)
-      returns: (base_type (identifier))
+      returns: (base_type name: (identifier))
       (parameters
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
         )
         (parameter
-          (identifier)
-          (base_type (identifier))
+          name: (identifier)
+          (base_type name: (identifier))
         )
         (parameter
-          (identifier)
-          (reference_type
-            (base_type (identifier))
+          name: (identifier)
+          (ref_type
+            (base_type name: (identifier))
           )
         )
         (parameter
-          (identifier)
+          name: (identifier)
           (ephemeral_type
-            (isolated_type
-              (base_type (identifier))
+            (iso_type
+              (base_type name: (identifier))
             )
           )
         )
         (parameter
-          (identifier)
+          name: (identifier)
           (aliased_type
             (tag_type
-              (base_type (identifier))
+              (base_type name: (identifier))
             )
           )
         )
@@ -161,8 +161,8 @@ use @union_type[(U8 | I8)]()
     (ffi_method
       (identifier)
       returns: (union_type
-        (base_type (identifier))
-        (base_type (identifier))
+        (base_type name: (identifier))
+        (base_type name: (identifier))
       )
       (parameters)
     )
@@ -182,8 +182,8 @@ use @union_type[(U8 & I8)]()
     (ffi_method
       (identifier)
       returns: (intersection_type
-        (base_type (identifier))
-        (base_type (identifier))
+        (base_type name: (identifier))
+        (base_type name: (identifier))
       )
       (parameters)
     )
@@ -203,10 +203,10 @@ use @tuple_type[(Foo, (Bar | Baz))]()
     (ffi_method
       (identifier)
       returns: (tuple_type
-        (base_type (identifier))
+        (base_type name: (identifier))
         (union_type
-          (base_type (identifier))
-          (base_type (identifier))
+          (base_type name: (identifier))
+          (base_type name: (identifier))
         )
       )
       (parameters)
@@ -227,7 +227,7 @@ use @grouped[(Foo)]()
     (ffi_method
       (identifier)
       returns: (tuple_type
-        (base_type (identifier))
+        (base_type name: (identifier))
       )
       (parameters)
     )
@@ -245,11 +245,13 @@ use @snot[Iterator[this->A]^]()
     (ffi_method
       (identifier)
       returns: (ephemeral_type
-        (generic_type
-          (identifier)
-          (viewpoint_type
-            (this)
-            (base_type (identifier))
+        (base_type
+          name: (identifier)
+          (type_args
+            (viewpoint_type
+              (this)
+              (base_type name: (identifier))
+            )
           )
         )
       )

--- a/test/corpus/use.txt
+++ b/test/corpus/use.txt
@@ -1,0 +1,260 @@
+=============
+Use statement
+=============
+
+use "math"
+
+---
+(source_file
+  (use_statement
+    (string (string_content))
+  )
+)
+
+=======================
+Use statement with name
+=======================
+
+use 
+foo = "foo"
+
+---
+
+(source_file 
+  (use_statement
+    (identifier)
+    (string (string_content))
+  ))
+
+=======================
+Multiple Use statements
+=======================
+
+use "foo"
+use bla12 
+= "blubb"
+use "foo"
+
+---
+
+(source_file
+  (use_statement
+    (string (string_content)))
+  (use_statement
+    (identifier)
+    (string (string_content)))
+  (use_statement
+    (string (string_content)))
+)
+
+========
+Use FFI
+========
+
+use @println[U64](i: U64, u: U64, ...)?
+
+---
+
+(source_file
+  (use_statement
+    (ffi_method
+      (identifier)
+      returns: (base_type (identifier))
+      (parameters
+        (parameter
+          (identifier)
+          (base_type (identifier))
+        )
+        (parameter
+          (identifier)
+          (base_type (identifier))
+        )
+        (parameter)
+      )
+    )
+  )
+)
+
+======
+Use if
+======
+
+use "package" if consume iso foo
+
+---
+
+(source_file
+  (use_statement
+    (string (string_content))
+    (platform_specifier
+      (if_block
+        (block 
+          (consume_expression 
+            (capability)
+            (identifier)
+          )
+        )
+      )
+    )
+  )
+)
+
+==================
+Use primitive type
+==================
+
+use @primitve_types[Bool](a: U64, b: I128, c: Main ref, d: U8 iso^, e: I8 tag!)
+
+---
+
+(source_file
+  (use_statement
+    (ffi_method
+      (identifier)
+      returns: (base_type (identifier))
+      (parameters
+        (parameter
+          (identifier)
+          (base_type (identifier))
+        )
+        (parameter
+          (identifier)
+          (base_type (identifier))
+        )
+        (parameter
+          (identifier)
+          (reference_type
+            (base_type (identifier))
+          )
+        )
+        (parameter
+          (identifier)
+          (ephemeral_type
+            (isolated_type
+              (base_type (identifier))
+            )
+          )
+        )
+        (parameter
+          (identifier)
+          (aliased_type
+            (tag_type
+              (base_type (identifier))
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+==============
+Use Union type
+==============
+
+use @union_type[(U8 | I8)]()
+
+---
+
+(source_file
+  (use_statement
+    (ffi_method
+      (identifier)
+      returns: (union_type
+        (base_type (identifier))
+        (base_type (identifier))
+      )
+      (parameters)
+    )
+  )
+)
+
+=====================
+Use Intersection type
+=====================
+
+use @union_type[(U8 & I8)]()
+
+---
+
+(source_file
+  (use_statement
+    (ffi_method
+      (identifier)
+      returns: (intersection_type
+        (base_type (identifier))
+        (base_type (identifier))
+      )
+      (parameters)
+    )
+  )
+)
+
+==============
+Use tuple type
+==============
+
+use @tuple_type[(Foo, (Bar | Baz))]()
+
+---
+
+(source_file
+  (use_statement
+    (ffi_method
+      (identifier)
+      returns: (tuple_type
+        (base_type (identifier))
+        (union_type
+          (base_type (identifier))
+          (base_type (identifier))
+        )
+      )
+      (parameters)
+    )
+  )
+)
+
+================
+Use grouped type
+================
+
+use @grouped[(Foo)]()
+
+---
+
+(source_file 
+  (use_statement
+    (ffi_method
+      (identifier)
+      returns: (tuple_type
+        (base_type (identifier))
+      )
+      (parameters)
+    )
+  )
+)
+
+==================
+Use ephemeral type
+==================
+
+use @snot[Iterator[this->A]^]()
+---
+(source_file 
+  (use_statement
+    (ffi_method
+      (identifier)
+      returns: (ephemeral_type
+        (generic_type
+          (identifier)
+          (viewpoint_type
+            (this)
+            (base_type (identifier))
+          )
+        )
+      )
+      (parameters)
+    )
+  )
+)
+


### PR DESCRIPTION
* Only allow type args on base-type
* only allow capability modifiers on base-type or lambda-type
* Add `generic_expression` to avoid any types as top-level in the `expression` tree
* Add a WIP `highlights.scm` query file for debugging some issues