### PR TITLE
Add custom scanner handling characters, strings and block-comments

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,6 +9,7 @@
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
+        "src/scanner.c"
       ],
       "cflags_c": [
         "-std=c99",

--- a/grammar.js
+++ b/grammar.js
@@ -33,8 +33,14 @@ module.exports = grammar({
   ],
 
   extras: $ => [
-    $.comment,
+    $.line_comment,
+    $.block_comment,
     /\s/,
+  ],
+  externals: $ => [
+    $.block_comment,
+    $.string,
+    $.character,
   ],
 
   supertypes: $ => [
@@ -691,66 +697,65 @@ module.exports = grammar({
         seq(dot_decimal, optional(exponent)),
       ));
     },
-
-    string: $ => choice($._string_literal, $._multiline_string_literal),
-
-    _string_literal: $ => seq(
-      '"',
-      repeat(choice(
-        $.string_content,
-        $._escape_sequence,
-      )),
-      '"',
-    ),
-    _multiline_string_literal: $ => prec.right(seq(
-      '"""',
-      repeat(choice(
-        alias($._multiline_string_content, $.string_content),
-        $._escape_sequence,
-      )),
-      '"""',
-    )),
-
-    character: $ => seq(
-      '\'',
-      repeat1(
-        choice(
-          $.character_content,
-          $._escape_sequence,
-        ),
-      ),
-      '\'',
-    ),
-    character_content: _ => token.immediate(prec(2, /[^'\\]+/)),
-
-    // Workaround to https://github.com/tree-sitter/tree-sitter/issues/1156
-    // We give names to the token_ constructs containing a regexp
-    // so as to obtain a node in the CST.
+    //    string: $ => choice($._string_literal, $._multiline_string_literal),
     //
-    string_content: _ => token.immediate(prec(1, /[^"\\]+/)),
-    _multiline_string_content: _ =>
-      prec.right(choice(
-        /[^"]+/,
-        seq(/"[^"]*/, repeat(/[^"]+/)),
-      )),
-
-
-    _escape_sequence: $ => choice(
-      prec(2, token.immediate(seq('\\', /[^abfnrtvxu'\"\\\?]/))),
-      prec(1, $.escape_sequence),
-    ),
-
-    escape_sequence: _ => token.immediate(seq(
-      '\\',
-      choice(
-        /[^xu0-7]/,
-        /[0-7]{1,3}/,
-        /x[0-9a-fA-F]{2}/,
-        /u[0-9a-fA-F]{4}/,
-        /u{[0-9a-fA-F]+}/,
-        /U[0-9a-fA-F]{8}/,
-      ))),
-
+    //    _string_literal: $ => seq(
+    //      '"',
+    //      repeat(choice(
+    //        $.string_content,
+    //        $._escape_sequence,
+    //      )),
+    //      '"',
+    //    ),
+    //    _multiline_string_literal: $ => prec.right(seq(
+    //      '"""',
+    //      repeat(choice(
+    //        alias($._multiline_string_content, $.string_content),
+    //        $._escape_sequence,
+    //      )),
+    //      '"""',
+    //    )),
+    //
+    //    character: $ => seq(
+    //      '\'',
+    //      repeat1(
+    //        choice(
+    //          $.character_content,
+    //          $._escape_sequence,
+    //        ),
+    //      ),
+    //      '\'',
+    //    ),
+    //    character_content: _ => token.immediate(prec(2, /[^'\\]+/)),
+    //
+    //    // Workaround to https://github.com/tree-sitter/tree-sitter/issues/1156
+    //    // We give names to the token_ constructs containing a regexp
+    //    // so as to obtain a node in the CST.
+    //    //
+    //    string_content: _ => token.immediate(prec(1, /[^"\\]+/)),
+    //    _multiline_string_content: _ =>
+    //      prec.right(choice(
+    //        /[^"]+/,
+    //        seq(/"[^"]*/, repeat(/[^"]+/)),
+    //      )),
+    //
+    //
+    //    _escape_sequence: $ => choice(
+    //      prec(2, token.immediate(seq('\\', /[^abfnrtvxu'\"\\\?]/))),
+    //      prec(1, $.escape_sequence),
+    //    ),
+    //
+    //    escape_sequence: _ => token.immediate(seq(
+    //      '\\',
+    //      choice(
+    //        /[^xu0-7]/,
+    //        /[0-7]{1,3}/,
+    //        /x[0-9a-fA-F]{2}/,
+    //        /u[0-9a-fA-F]{4}/,
+    //        /u{[0-9a-fA-F]+}/,
+    //        /U[0-9a-fA-F]{8}/,
+    //      ))),
+    //
     boolean: _ => choice('true', 'false'),
 
     identifier: _ => /[a-zA-Z_][a-zA-Z0-9_']*/,
@@ -758,10 +763,12 @@ module.exports = grammar({
 
     this: _ => 'this',
 
-    comment: _ => token(choice(
+    line_comment: _ => token(
+      // choice(
       seq('//', /(\\(.|\r?\n)|[^\\\n])*/),
-      seq('/*', /[^*]*\*+([^/*][^*]*\*+)*/, '/'),
-    )),
+      // seq('/*', /[^*]*\*+([^/*][^*]*\*+)*/, '/'),
+      // )
+    ),
   },
 });
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,4 +1,7 @@
-(comment) @comment
+[
+  (line_comment)
+  (block_comment)
+] @comment
 
 [
   "("

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5554,240 +5554,6 @@
         ]
       }
     },
-    "string": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_string_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_multiline_string_literal"
-        }
-      ]
-    },
-    "_string_literal": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "\""
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "string_content"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_escape_sequence"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "\""
-        }
-      ]
-    },
-    "_multiline_string_literal": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "\"\"\""
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_multiline_string_content"
-                  },
-                  "named": true,
-                  "value": "string_content"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_escape_sequence"
-                }
-              ]
-            }
-          },
-          {
-            "type": "STRING",
-            "value": "\"\"\""
-          }
-        ]
-      }
-    },
-    "character": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "'"
-        },
-        {
-          "type": "REPEAT1",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "character_content"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_escape_sequence"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "'"
-        }
-      ]
-    },
-    "character_content": {
-      "type": "IMMEDIATE_TOKEN",
-      "content": {
-        "type": "PREC",
-        "value": 2,
-        "content": {
-          "type": "PATTERN",
-          "value": "[^'\\\\]+"
-        }
-      }
-    },
-    "string_content": {
-      "type": "IMMEDIATE_TOKEN",
-      "content": {
-        "type": "PREC",
-        "value": 1,
-        "content": {
-          "type": "PATTERN",
-          "value": "[^\"\\\\]+"
-        }
-      }
-    },
-    "_multiline_string_content": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "PATTERN",
-            "value": "[^\"]+"
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "PATTERN",
-                "value": "\"[^\"]*"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[^\"]+"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_escape_sequence": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PREC",
-          "value": 2,
-          "content": {
-            "type": "IMMEDIATE_TOKEN",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "\\"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "[^abfnrtvxu'\\\"\\\\\\?]"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "type": "PREC",
-          "value": 1,
-          "content": {
-            "type": "SYMBOL",
-            "name": "escape_sequence"
-          }
-        }
-      ]
-    },
-    "escape_sequence": {
-      "type": "IMMEDIATE_TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "\\"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PATTERN",
-                "value": "[^xu0-7]"
-              },
-              {
-                "type": "PATTERN",
-                "value": "[0-7]{1,3}"
-              },
-              {
-                "type": "PATTERN",
-                "value": "x[0-9a-fA-F]{2}"
-              },
-              {
-                "type": "PATTERN",
-                "value": "u[0-9a-fA-F]{4}"
-              },
-              {
-                "type": "PATTERN",
-                "value": "u{[0-9a-fA-F]+}"
-              },
-              {
-                "type": "PATTERN",
-                "value": "U[0-9a-fA-F]{8}"
-              }
-            ]
-          }
-        ]
-      }
-    },
     "boolean": {
       "type": "CHOICE",
       "members": [
@@ -5831,40 +5597,18 @@
       "type": "STRING",
       "value": "this"
     },
-    "comment": {
+    "line_comment": {
       "type": "TOKEN",
       "content": {
-        "type": "CHOICE",
+        "type": "SEQ",
         "members": [
           {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "//"
-              },
-              {
-                "type": "PATTERN",
-                "value": "(\\\\(.|\\r?\\n)|[^\\\\\\n])*"
-              }
-            ]
+            "type": "STRING",
+            "value": "//"
           },
           {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "/*"
-              },
-              {
-                "type": "PATTERN",
-                "value": "[^*]*\\*+([^/*][^*]*\\*+)*"
-              },
-              {
-                "type": "STRING",
-                "value": "/"
-              }
-            ]
+            "type": "PATTERN",
+            "value": "(\\\\(.|\\r?\\n)|[^\\\\\\n])*"
           }
         ]
       }
@@ -5873,7 +5617,11 @@
   "extras": [
     {
       "type": "SYMBOL",
-      "name": "comment"
+      "name": "line_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "block_comment"
     },
     {
       "type": "PATTERN",
@@ -5895,7 +5643,20 @@
     ]
   ],
   "precedences": [],
-  "externals": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "block_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "string"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "character"
+    }
+  ],
   "inline": [],
   "supertypes": [
     "expression",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -829,25 +829,6 @@
     }
   },
   {
-    "type": "character",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "character_content",
-          "named": true
-        },
-        {
-          "type": "escape_sequence",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "class_definition",
     "named": true,
     "fields": {},
@@ -2042,30 +2023,6 @@
     }
   },
   {
-    "type": "string",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "escape_sequence",
-          "named": true
-        },
-        {
-          "type": "string_content",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "string_content",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "struct_definition",
     "named": true,
     "fields": {},
@@ -2541,14 +2498,6 @@
     "named": false
   },
   {
-    "type": "\"",
-    "named": false
-  },
-  {
-    "type": "\"\"\"",
-    "named": false
-  },
-  {
     "type": "#alias",
     "named": false
   },
@@ -2594,10 +2543,6 @@
   },
   {
     "type": "&",
-    "named": false
-  },
-  {
-    "type": "'",
     "named": false
   },
   {
@@ -2797,6 +2742,10 @@
     "named": false
   },
   {
+    "type": "block_comment",
+    "named": true
+  },
+  {
     "type": "box",
     "named": false
   },
@@ -2805,16 +2754,12 @@
     "named": false
   },
   {
-    "type": "character_content",
+    "type": "character",
     "named": true
   },
   {
     "type": "class",
     "named": false
-  },
-  {
-    "type": "comment",
-    "named": true
   },
   {
     "type": "compile_error",
@@ -2858,10 +2803,6 @@
   },
   {
     "type": "error",
-    "named": true
-  },
-  {
-    "type": "escape_sequence",
     "named": true
   },
   {
@@ -2921,6 +2862,10 @@
     "named": false
   },
   {
+    "type": "line_comment",
+    "named": true
+  },
+  {
     "type": "match",
     "named": false
   },
@@ -2963,6 +2908,10 @@
   {
     "type": "return",
     "named": false
+  },
+  {
+    "type": "string",
+    "named": true
   },
   {
     "type": "struct",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,0 +1,219 @@
+#include <tree_sitter/parser.h>
+#include <wctype.h>
+#include <stdio.h>
+
+enum TokenType {
+  BLOCK_COMMENT,
+  STRING,
+  CHARACTER,
+};
+
+
+bool tree_sitter_pony_external_scanner_scan(
+  void *payload,
+  TSLexer *lexer,
+  const bool *valid_symbols
+) {
+
+  // skip whitespace, but mark if we found newlines
+  while (iswspace(lexer->lookahead))
+  {
+    lexer->advance(lexer, true);
+  }
+
+ 
+
+  // handle block comments
+  if (valid_symbols[BLOCK_COMMENT] && lexer->lookahead == '/')
+  {
+    lexer->advance(lexer, false);
+    if (lexer->lookahead != '*')
+    {
+      return false;
+    }
+    lexer->advance(lexer, false);
+
+    // we are inside a block comment
+    bool after_asterisk = false;
+    unsigned nesting_depth = 1;
+    for (;;)
+    {
+      switch (lexer->lookahead)
+      {
+        case '\0':
+          return false;
+        case '*':
+          lexer->advance(lexer, false);
+          after_asterisk = true;
+          break;
+        case '/':
+          if (after_asterisk)
+          {
+            lexer->advance(lexer, false);
+            after_asterisk = false;
+            nesting_depth--;
+            if (nesting_depth == 0)
+            {
+              lexer->result_symbol = BLOCK_COMMENT;
+              return true;
+            }
+          }
+          else
+          {
+            lexer->advance(lexer, false);
+            after_asterisk = false;
+            if (lexer->lookahead == '*')
+            {
+              nesting_depth++;
+              lexer->advance(lexer, false);
+            }
+          }
+        default:
+          lexer->advance(lexer, false);
+          after_asterisk = false;
+          break;
+      }
+    }
+  }
+
+  if (valid_symbols[CHARACTER] && lexer->lookahead == '\'')
+  {
+    // CHARACTER LITERAL 'A'
+    lexer->advance(lexer, false);
+    bool inside_escape = false;
+    for (;;)
+    {
+      switch(lexer->lookahead)
+      {
+        case '\0':
+          return false;
+        case '\\':
+          // escape
+          lexer->advance(lexer, false);
+          // toggle, as we are getting out of a quote when we have double
+          // backslashes
+          inside_escape = !inside_escape;
+          break;
+        case '\'':
+          lexer->advance(lexer, false);
+          // terminating single-quote
+          if(!inside_escape)
+          {
+            lexer->result_symbol = CHARACTER;
+            return true;
+          }
+          else
+          {
+            // leaving the escaped quote
+            inside_escape = false;
+          }
+          break;
+        default:
+          lexer->advance(lexer, false);
+          inside_escape = false;
+          break;
+      }
+    }
+  }
+  else if (valid_symbols[STRING])
+  {
+    // handle strings, docstrings and quoting
+    uint32_t quote_count = 0;
+    while (lexer->lookahead == '"' && quote_count < 3) {
+      quote_count++;
+      lexer->advance(lexer, false);
+    }
+
+    switch (quote_count)
+    {
+      case 2:
+        // empty string
+        lexer->result_symbol = STRING;
+        return true;
+      case 1:
+        // single quote string - handle quoting
+        {
+          bool escaped_quote = false;
+          for (;;)
+          {
+            switch(lexer->lookahead)
+            {
+              case '\0':
+                return false;
+              case '\\':
+                lexer->advance(lexer, false);
+                // toggle, as we are getting out of a quote when we have double
+                // backslashes
+                escaped_quote = !escaped_quote;
+                break;
+              case '"':
+                lexer->advance(lexer, false);
+                if (!escaped_quote)
+                {
+                  // terminating quote
+                  lexer->result_symbol = STRING;
+                  return true;
+                }
+                else
+                {
+                  // we now leave the escaped quote
+                  escaped_quote = false;
+                }
+                break;
+              default:
+                lexer->advance(lexer, false);
+                escaped_quote = false;
+                break;
+            }
+          }
+
+          break;
+        }
+      case 3:
+        // within docstring - no quoting
+        {
+          quote_count = 0;
+          while (quote_count < 3) {
+            if (lexer->lookahead == '"') {
+              quote_count++;
+              lexer->advance(lexer, false);
+            } else {
+              quote_count = 0;
+              if (lexer->lookahead == 0) return false;
+              lexer->advance(lexer, false);
+            }
+          }
+          // consume additional quotes
+          while (lexer->lookahead == '"')
+            lexer->advance(lexer, false);
+
+          lexer->result_symbol = STRING;
+          return true;
+        }
+      default:
+        // no quote
+        return false;
+    }
+  }
+  return false;
+}
+
+
+void *tree_sitter_pony_external_scanner_create() {
+  return NULL;
+}
+
+void tree_sitter_pony_external_scanner_destroy(void *payload) {}
+
+unsigned tree_sitter_pony_external_scanner_serialize(
+  void *payload,
+  char *buffer
+) {
+  return 0;
+}
+
+void tree_sitter_pony_external_scanner_deserialize(
+  void *payload,
+  const char *buffer,
+  unsigned length
+) {}

--- a/test/corpus/characters.txt
+++ b/test/corpus/characters.txt
@@ -7,11 +7,11 @@ use "snot" if 'A'
 ---
 (source_file
   (use_statement
-    (string (string_content))
+    (string)
     (platform_specifier
       (if_block
         (block
-          (literal (character (character_content)))
+          (literal (character))
         )
       )
     )
@@ -26,15 +26,12 @@ use "snot" if '\xFF\''
 ---
 (source_file
   (use_statement
-    (string (string_content))
+    (string)
     (platform_specifier
       (if_block
         (block
           (literal 
-            (character
-              (escape_sequence)
-              (escape_sequence)
-            )
+            (character)
           )
         )
       )
@@ -50,16 +47,12 @@ use "snot" if 'A\nBCDEFGH'
 ---
 (source_file
   (use_statement
-    (string (string_content))
+    (string)
     (platform_specifier
       (if_block
         (block
           (literal
-            (character
-              (character_content)
-              (escape_sequence)
-              (character_content)
-            )
+            (character)
           )
         )
       )

--- a/test/corpus/entity.txt
+++ b/test/corpus/entity.txt
@@ -31,21 +31,21 @@ actor Main
 ---
 
 (source_file 
-  (string (string_content))
+  (string)
   (actor_definition
     (identifier) 
-    docstring: (string (string_content))
+    docstring: (string)
     (field
       name: (identifier)
       (base_type name: (identifier))
-      docstring: (string (string_content))
+      docstring: (string)
     )
     (field
       name: (identifier)
       (ref_type
         (base_type name: (identifier)))
-      (literal (string (string_content)))
-      docstring: (string (string_content))
+      (literal (string))
+      docstring: (string)
     )
     (field
       name: (identifier)
@@ -69,7 +69,7 @@ actor Main
         )
       )
       (block
-        (literal (string (string_content)))
+        (literal (string))
         (consume_expression (identifier))
       )
     )
@@ -88,7 +88,7 @@ actor Main
         )
       )
       (block
-        (literal (string (string_content)))
+        (literal (string))
       )
     )
   )
@@ -112,7 +112,7 @@ actor Main
 ---
 (source_file
   (use_statement
-    (string (string_content))
+    (string)
     (platform_specifier (if_block (block (identifier))))
   )
   (actor_definition
@@ -135,7 +135,7 @@ actor Main
             )
           )
           (binary_expression
-            left: (literal (string (string_content)))
+            left: (literal (string))
             right: (literal (number))
           )
         )
@@ -207,7 +207,7 @@ class MT is Random
   (class_definition
     (identifier)
     (base_type name: (identifier))
-    (string (string_content))
+    (string)
     (field
       name: (identifier)
       (base_type
@@ -236,7 +236,7 @@ class MT is Random
         )
       )
       (block
-        (literal (string (string_content)))
+        (literal (string))
         (assignment_expression
           (identifier)
           (block
@@ -282,7 +282,7 @@ interface Notify
 (source_file
   (interface_definition
     (identifier)
-    (string (string_content))
+    (string)
     (method
       (capability)
       (identifier)
@@ -301,7 +301,7 @@ interface Notify
         ) 
       )
       returns: (base_type name: (identifier))
-      (string (string_content))
+      (string)
     )
   )
 )

--- a/test/corpus/exprs.txt
+++ b/test/corpus/exprs.txt
@@ -8,7 +8,7 @@ use "snot" if not badger
 
 (source_file
   (use_statement
-    (string (string_content))
+    (string)
     (platform_specifier
       (if_block
         (block
@@ -37,7 +37,7 @@ use "snot" if [
 ---
 (source_file
   (use_statement
-    (string (string_content))
+    (string)
     (platform_specifier
       (if_block
         (block
@@ -108,8 +108,8 @@ primitive Snot
       (identifier)
       (parameters)
       (block
-        (literal (string (string_content)))
-        (literal (string (string_content)))
+        (literal (string))
+        (literal (string))
       )
     )
   )
@@ -188,13 +188,13 @@ primitive Foo
         (if_statement
           (if_block
             (block
-              (literal (string (string_content)))
+              (literal (string))
               (literal (boolean))
             )
           )
           (then_block
             (block
-              (literal (string (string_content)))
+              (literal (string))
             )
           )
         )
@@ -280,7 +280,7 @@ primitive Foo
         )
         (call_expression
           callee: (ffi_identifier (identifier))
-          (literal (string (string_content)))
+          (literal (string))
         )
       )
     )
@@ -317,17 +317,17 @@ primitive Foo[A]
           (base_type (identifier))
           (base_type (identifier))
           (then_block
-            (block (literal (string (string_content))))
+            (block (literal (string)))
           )
           (elseiftype_block
             (base_type (identifier))
             (base_type (identifier))
             (then_block
-              (block (literal (string (string_content))))
+              (block (literal (string)))
             )
           )
           (else_block
-            (block (literal (string (string_content))))
+            (block (literal (string)))
           )
         )
       )
@@ -465,3 +465,18 @@ primitive Foo
   )
 )
 
+
+====================
+Nested Block Comment
+====================
+
+/**
+  *
+  /* nested */
+  */
+trait Empty
+---
+(source_file
+  (block_comment)
+  (trait_definition (identifier))
+)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -34,7 +34,7 @@ primitive ContainsWith
             )
           )
           (do_block
-            (comment)
+            (line_comment)
             (block
               (call_expression
                 callee: (member_expression

--- a/test/corpus/strings.txt
+++ b/test/corpus/strings.txt
@@ -7,11 +7,7 @@ Single Quoted String
 ---
 
 (source_file 
-  (string
-    (string_content)
-    (escape_sequence)
-    (string_content)
-  )
+  (string)
 )
 
 ===================
@@ -40,7 +36,7 @@ use
 ---
 
 (source_file 
-  (string (string_content))
+  (string)
 )
 
 ===================
@@ -66,7 +62,7 @@ use "foo"
 ---
 
 (source_file
-  (string (string_content) (string_content) (string_content))
+  (string)
 )
 
 =========================
@@ -80,7 +76,7 @@ Block Quote Triple String
 
 ---
 
-(source_file (comment))
+(source_file (block_comment))
 
 ================================
 Block Quote before Triple String
@@ -94,6 +90,29 @@ hdfjdf
 ---
 
 (source_file 
-  (comment)
-  (string (string_content))
+  (block_comment)
+  (string)
 )
+
+==============
+4-quote string
+==============
+
+primitive Foo
+  fun apply(): String =>
+    """"Foo""""
+
+---
+(source_file
+  (primitive_definition
+    (identifier)
+    (method
+      (identifier)
+      (parameters)
+      returns: (base_type name: (identifier))
+      (block (literal (string)))
+    )
+  )
+)
+
+

--- a/test/corpus/use.txt
+++ b/test/corpus/use.txt
@@ -7,7 +7,7 @@ use "math"
 ---
 (source_file
   (use_statement
-    (string (string_content))
+    (string)
   )
 )
 
@@ -23,7 +23,7 @@ foo = "foo"
 (source_file 
   (use_statement
     (identifier)
-    (string (string_content))
+    (string)
   ))
 
 =======================
@@ -39,12 +39,12 @@ use "foo"
 
 (source_file
   (use_statement
-    (string (string_content)))
+    (string))
   (use_statement
     (identifier)
-    (string (string_content)))
+    (string))
   (use_statement
-    (string (string_content)))
+    (string))
 )
 
 ========
@@ -85,7 +85,7 @@ use "package" if consume iso foo
 
 (source_file
   (use_statement
-    (string (string_content))
+    (string)
     (platform_specifier
       (if_block
         (block 


### PR DESCRIPTION
As this might be a bit controversial, I made a separate PR for this.
We can trim the scanner down to only handle block-comments if you find another way to work with triple-quoted strings.
I can also improve the scanner to emit `string_content` and `escape_sequence` tokens.