### PR TITLE
Add several nodes to better support textobject queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-pony"
 description = "Pony grammar for tree-sitter"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
 	"Amaan Qureshi <amaanq12@gmail.com>",
 	"Matthias Wahl <matthiaswahl@m7w3.de>",
@@ -21,7 +21,7 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.20.9"
+tree-sitter = "~0.20.10"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -8,8 +8,8 @@ way.)
 
 ```toml
 [dependencies]
-tree-sitter = "~0.20.9"
-tree-sitter-pony = "0.0.2"
+tree-sitter = "~0.20.10"
+tree-sitter-pony = "0.0.3"
 ```
 
 Typically, you will use the [language][language func] function to add this

--- a/grammar.js
+++ b/grammar.js
@@ -94,6 +94,27 @@ module.exports = grammar({
       optional($.string),
     ),
 
+    members: $ => choice(
+      repeat1($.field),
+      repeat1(
+        choice(
+          $.constructor,
+          $.method,
+          $.behavior,
+        ),
+      ),
+      seq(
+        repeat1($.field),
+        repeat1(
+          choice(
+            $.constructor,
+            $.method,
+            $.behavior,
+          ),
+        ),
+      ),
+    ),
+
     actor_definition: $ => seq(
       'actor',
       optional($.annotation),
@@ -101,12 +122,7 @@ module.exports = grammar({
       optional($.generic_parameters),
       optional(seq('is', $.type)),
       optional($.string),
-      repeat($.field),
-      repeat(choice(
-        $.constructor,
-        $.method,
-        $.behavior,
-      )),
+      optional($.members),
     ),
 
     class_definition: $ => seq(
@@ -117,12 +133,7 @@ module.exports = grammar({
       optional($.generic_parameters),
       optional(seq('is', $.type)),
       optional($.string),
-      repeat($.field),
-      repeat(choice(
-        $.constructor,
-        $.method,
-        $.behavior,
-      )),
+      optional($.members),
     ),
 
     primitive_definition: $ => seq(
@@ -132,10 +143,7 @@ module.exports = grammar({
       optional($.generic_parameters),
       optional(seq('is', $.type)),
       optional($.string),
-      repeat(choice(
-        $.constructor,
-        $.method,
-      )),
+      optional($.members),
     ),
 
     interface_definition: $ => seq(
@@ -146,11 +154,7 @@ module.exports = grammar({
       optional($.generic_parameters),
       optional(seq('is', $.type)),
       optional($.string),
-      repeat(choice(
-        $.constructor,
-        $.method,
-        $.behavior,
-      )),
+      optional($.members),
     ),
 
     trait_definition: $ => seq(
@@ -161,11 +165,7 @@ module.exports = grammar({
       optional($.generic_parameters),
       optional(seq('is', $.type)),
       optional($.string),
-      repeat(choice(
-        $.constructor,
-        $.method,
-        $.behavior,
-      )),
+      optional($.members),
     ),
 
     struct_definition: $ => seq(
@@ -176,11 +176,7 @@ module.exports = grammar({
       optional($.generic_parameters),
       optional(seq('is', $.type)),
       optional($.string),
-      repeat($.field),
-      repeat(choice(
-        $.constructor,
-        $.method,
-      )),
+      optional($.members),
     ),
 
     field: $ => seq(
@@ -453,8 +449,9 @@ module.exports = grammar({
 
     named_arguments: $ => seq(
       'where',
-      commaSep(seq($.identifier, '=', $.expression)),
+      commaSep($.named_argument),
     ),
+    named_argument: $ => seq($.identifier, '=', $.expression),
 
     lambda_expression: $ => seq(
       optional('@'),
@@ -675,8 +672,7 @@ module.exports = grammar({
       'object',
       optional($.capability),
       optional(seq('is', $.type)),
-      repeat($.field),
-      repeat(choice($.method, $.behavior)),
+      optional($.members),
       'end',
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -435,12 +435,15 @@ module.exports = grammar({
 
     call_expression: $ => prec(PREC.CALL, seq(
       field('callee', $.expression),
-      token.immediate('('),
-      commaSep($.expression),
-      optional($.named_arguments),
-      ')',
+      $.arguments,
       optional('?'),
     )),
+    arguments: $ => seq(
+      token.immediate('('),
+      field('positional', commaSep($.expression)),
+      optional($.named_arguments),
+      ')',
+    ),
 
     chain_expression: $ => prec.right(PREC.CALL, seq(
       $.expression,

--- a/grammar.js
+++ b/grammar.js
@@ -369,11 +369,13 @@ module.exports = grammar({
       $.error,
       $.compile_intrinsic,
       $.compile_error,
+      $.location,
     ),
 
     error: _ => 'error',
     compile_intrinsic: _ => 'compile_intrinsic',
     compile_error: $ => prec.left(seq('compile_error', optional($.string))),
+    location: _ => '__loc',
 
     unary_expression: $ => prec.left(PREC.UNARY, seq(
       field('operator', choice('-', 'not', '-~', 'addressof', 'digestof')),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-pony",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pony grammar for tree-sitter",
   "main": "bindings/node",
   "keywords": [
@@ -21,9 +21,9 @@
     "nan": "^2.17.0"
   },
   "devDependencies": {
-    "eslint": "^8.36.0",
+    "eslint": "^8.39.0",
     "eslint-config-google": "^0.14.0",
-    "tree-sitter-cli": "^0.20.7"
+    "tree-sitter-cli": "^0.20.8"
   },
   "repository": "https://github.com/amaanq/tree-sitter-pony",
   "scripts": {

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -110,6 +110,7 @@
 (identifier) @variable
 
 (this) @variable.builtin
+(location) @preproc
 
 ; Fields
 

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -20,6 +20,7 @@
 (trait_definition (identifier) @name) @definition.interface
 (interface_definition (identifier) @name) @definition.interface
 
+(constructor (identifier) @name) @definition.method
 (method (identifier) @name) @definition.method
 (behavior (identifier) @name) @definition.method
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3924,13 +3924,38 @@
             }
           },
           {
-            "type": "IMMEDIATE_TOKEN",
-            "content": {
-              "type": "STRING",
-              "value": "("
-            }
+            "type": "SYMBOL",
+            "name": "arguments"
           },
           {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "?"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "arguments": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "("
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "positional",
+          "content": {
             "type": "CHOICE",
             "members": [
               {
@@ -3962,37 +3987,25 @@
                 "type": "BLANK"
               }
             ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "named_arguments"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": ")"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "?"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
           }
-        ]
-      }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "named_arguments"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
     },
     "chain_expression": {
       "type": "PREC_RIGHT",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2366,6 +2366,10 @@
         {
           "type": "SYMBOL",
           "name": "compile_error"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "location"
         }
       ]
     },
@@ -2401,6 +2405,10 @@
           }
         ]
       }
+    },
+    "location": {
+      "type": "STRING",
+      "value": "__loc"
     },
     "unary_expression": {
       "type": "PREC_LEFT",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -231,6 +231,70 @@
         }
       ]
     },
+    "members": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "SYMBOL",
+            "name": "field"
+          }
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "constructor"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "method"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "behavior"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "REPEAT1",
+              "content": {
+                "type": "SYMBOL",
+                "name": "field"
+              }
+            },
+            {
+              "type": "REPEAT1",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "constructor"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "method"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "behavior"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
     "actor_definition": {
       "type": "SEQ",
       "members": [
@@ -300,31 +364,16 @@
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "field"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "constructor"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "behavior"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "members"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -409,31 +458,16 @@
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "field"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "constructor"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "behavior"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "members"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -506,20 +540,16 @@
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "constructor"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "members"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -604,24 +634,16 @@
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "constructor"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "behavior"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "members"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -706,24 +728,16 @@
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "constructor"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "behavior"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "members"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -808,27 +822,16 @@
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "field"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "constructor"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "members"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -4042,21 +4045,8 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "identifier"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "="
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "expression"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "named_argument"
                 },
                 {
                   "type": "REPEAT",
@@ -4068,21 +4058,8 @@
                         "value": ","
                       },
                       {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "identifier"
-                          },
-                          {
-                            "type": "STRING",
-                            "value": "="
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "expression"
-                          }
-                        ]
+                        "type": "SYMBOL",
+                        "name": "named_argument"
                       }
                     ]
                   }
@@ -4093,6 +4070,23 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "named_argument": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
         }
       ]
     },
@@ -5506,27 +5500,16 @@
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "field"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "method"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "behavior"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "members"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -415,6 +415,36 @@
     }
   },
   {
+    "type": "arguments",
+    "named": true,
+    "fields": {
+      "positional": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "named_arguments",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "array_literal",
     "named": true,
     "fields": {},
@@ -779,15 +809,11 @@
       }
     },
     "children": {
-      "multiple": true,
-      "required": false,
+      "multiple": false,
+      "required": true,
       "types": [
         {
-          "type": "expression",
-          "named": true
-        },
-        {
-          "type": "named_arguments",
+          "type": "arguments",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -312,18 +312,6 @@
           "named": true
         },
         {
-          "type": "behavior",
-          "named": true
-        },
-        {
-          "type": "constructor",
-          "named": true
-        },
-        {
-          "type": "field",
-          "named": true
-        },
-        {
           "type": "generic_parameters",
           "named": true
         },
@@ -332,7 +320,7 @@
           "named": true
         },
         {
-          "type": "method",
+          "type": "members",
           "named": true
         },
         {
@@ -917,19 +905,7 @@
           "named": true
         },
         {
-          "type": "behavior",
-          "named": true
-        },
-        {
           "type": "capability",
-          "named": true
-        },
-        {
-          "type": "constructor",
-          "named": true
-        },
-        {
-          "type": "field",
           "named": true
         },
         {
@@ -941,7 +917,7 @@
           "named": true
         },
         {
-          "type": "method",
+          "type": "members",
           "named": true
         },
         {
@@ -1425,15 +1401,7 @@
           "named": true
         },
         {
-          "type": "behavior",
-          "named": true
-        },
-        {
           "type": "capability",
-          "named": true
-        },
-        {
-          "type": "constructor",
           "named": true
         },
         {
@@ -1445,7 +1413,7 @@
           "named": true
         },
         {
-          "type": "method",
+          "type": "members",
           "named": true
         },
         {
@@ -1669,6 +1637,33 @@
     }
   },
   {
+    "type": "members",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "behavior",
+          "named": true
+        },
+        {
+          "type": "constructor",
+          "named": true
+        },
+        {
+          "type": "field",
+          "named": true
+        },
+        {
+          "type": "method",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "method",
     "named": true,
     "fields": {
@@ -1719,6 +1714,21 @@
     }
   },
   {
+    "type": "named_argument",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "named_arguments",
     "named": true,
     "fields": {},
@@ -1727,7 +1737,7 @@
       "required": false,
       "types": [
         {
-          "type": "expression",
+          "type": "named_argument",
           "named": true
         }
       ]
@@ -1742,19 +1752,11 @@
       "required": false,
       "types": [
         {
-          "type": "behavior",
-          "named": true
-        },
-        {
           "type": "capability",
           "named": true
         },
         {
-          "type": "field",
-          "named": true
-        },
-        {
-          "type": "method",
+          "type": "members",
           "named": true
         },
         {
@@ -1867,10 +1869,6 @@
           "named": true
         },
         {
-          "type": "constructor",
-          "named": true
-        },
-        {
           "type": "generic_parameters",
           "named": true
         },
@@ -1879,7 +1877,7 @@
           "named": true
         },
         {
-          "type": "method",
+          "type": "members",
           "named": true
         },
         {
@@ -2089,14 +2087,6 @@
           "named": true
         },
         {
-          "type": "constructor",
-          "named": true
-        },
-        {
-          "type": "field",
-          "named": true
-        },
-        {
           "type": "generic_parameters",
           "named": true
         },
@@ -2105,7 +2095,7 @@
           "named": true
         },
         {
-          "type": "method",
+          "type": "members",
           "named": true
         },
         {
@@ -2170,15 +2160,7 @@
           "named": true
         },
         {
-          "type": "behavior",
-          "named": true
-        },
-        {
           "type": "capability",
-          "named": true
-        },
-        {
-          "type": "constructor",
           "named": true
         },
         {
@@ -2190,7 +2172,7 @@
           "named": true
         },
         {
-          "type": "method",
+          "type": "members",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -80,6 +80,10 @@
         "named": true
       },
       {
+        "type": "location",
+        "named": true
+      },
+      {
         "type": "match_statement",
         "named": true
       },
@@ -2903,6 +2907,10 @@
   },
   {
     "type": "line_comment",
+    "named": true
+  },
+  {
+    "type": "location",
     "named": true
   },
   {

--- a/test/corpus/entity.txt
+++ b/test/corpus/entity.txt
@@ -37,59 +37,60 @@ actor Main
     (identifier)
     (string
       (string_content))
-    (field
-      (identifier)
-      (base_type
-        (identifier))
-      (string
-        (string_content)))
-    (field
-      (identifier)
-      (ref_type
-        (base_type
-          (identifier)))
-      (string
-        (string_content))
-      (string
-        (string_content)))
-    (field
-      (identifier)
-      (intersection_type
+    (members
+      (field
+        (identifier)
         (base_type
           (identifier))
-        (base_type
-          (identifier)
-          (type_args
-            (base_type
-              (identifier))))))
-    (constructor
-      (capability)
-      (identifier)
-      (parameters
-        (parameter
-          (identifier)
+        (string
+          (string_content)))
+      (field
+        (identifier)
+        (ref_type
           (base_type
-            (identifier))))
-      (block
+            (identifier)))
         (string
           (string_content))
-        (consume_statement
-          (identifier))))
-    (behavior
-      (identifier)
-      (generic_parameters
-        (generic_parameter
-          (identifier)
-          (base_type
-            (identifier))))
-      (parameters
-        (parameter
-          (identifier)
-          (base_type
-            (identifier))))
-      (block
         (string
-          (string_content))))))
+          (string_content)))
+      (field
+        (identifier)
+        (intersection_type
+          (base_type
+            (identifier))
+          (base_type
+            (identifier)
+            (type_args
+              (base_type
+                (identifier))))))
+      (constructor
+        (capability)
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (base_type
+              (identifier))))
+        (block
+          (string
+            (string_content))
+          (consume_statement
+            (identifier))))
+      (behavior
+        (identifier)
+        (generic_parameters
+          (generic_parameter
+            (identifier)
+            (base_type
+              (identifier))))
+        (parameters
+          (parameter
+            (identifier)
+            (base_type
+              (identifier))))
+        (block
+          (string
+            (string_content)))))))
 
 =============
 Method Quirks
@@ -118,55 +119,56 @@ actor Main
           (identifier)))))
   (actor_definition
     (identifier)
-    (constructor
-      (identifier)
-      (parameters
-        (parameter
-          (identifier)
-          (base_type
-            (identifier))))
-      (block
-        (call_expression
-          (member_expression
+    (members
+      (constructor
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (base_type
+              (identifier))))
+        (block
+          (call_expression
             (member_expression
+              (member_expression
+                (identifier)
+                (identifier))
+              (identifier))
+            (arguments
+              (binary_expression
+                (string
+                  (string_content))
+                (number))))))
+      (method
+        (capability)
+        (identifier)
+        (parameters)
+        (base_type
+          (identifier))
+        (block
+          (boolean)))
+      (behavior
+        (identifier)
+        (generic_parameters
+          (generic_parameter
+            (identifier)
+            (base_type
+              (identifier))))
+        (parameters
+          (parameter
+            (identifier)
+            (base_type
+              (identifier)
+              (type_args
+                (base_type
+                  (identifier))))))
+        (block
+          (call_expression
+            (partial_application
               (identifier)
               (identifier))
-            (identifier))
-          (arguments
-            (binary_expression
-              (string
-                (string_content))
-              (number))))))
-    (method
-      (capability)
-      (identifier)
-      (parameters)
-      (base_type
-        (identifier))
-      (block
-        (boolean)))
-    (behavior
-      (identifier)
-      (generic_parameters
-        (generic_parameter
-          (identifier)
-          (base_type
-            (identifier))))
-      (parameters
-        (parameter
-          (identifier)
-          (base_type
-            (identifier)
-            (type_args
-              (base_type
-                (identifier))))))
-      (block
-        (call_expression
-          (partial_application
-            (identifier)
-            (identifier))
-          (arguments
-            (float)))))))
+            (arguments
+              (float))))))))
 
 ======
 MT
@@ -197,52 +199,53 @@ class MT is Random
       (identifier))
     (string
       (string_content))
-    (field
-      (identifier)
-      (base_type
+    (members
+      (field
         (identifier)
-        (type_args
-          (base_type
-            (identifier)))))
-    (field
-      (identifier)
-      (base_type
-        (identifier)))
-    (constructor
-      (identifier)
-      (parameters
-        (parameter
+        (base_type
           (identifier)
-          (base_type
-            (identifier))
-          (number))
-        (parameter
-          (identifier)
-          (base_type
-            (identifier))
-          (number)))
-      (block
-        (string
-          (string_content))
-        (assignment_expression
-          (identifier)
-          (block
-            (call_expression
-              (generic_expression
-                (identifier)
-                (type_args
-                  (base_type
-                    (identifier))))
-              (arguments
-                (call_expression
+          (type_args
+            (base_type
+              (identifier)))))
+      (field
+        (identifier)
+        (base_type
+          (identifier)))
+      (constructor
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (base_type
+              (identifier))
+            (number))
+          (parameter
+            (identifier)
+            (base_type
+              (identifier))
+            (number)))
+        (block
+          (string
+            (string_content))
+          (assignment_expression
+            (identifier)
+            (block
+              (call_expression
+                (generic_expression
                   (identifier)
-                  (arguments))))))
-        (assignment_expression
-          (identifier)
-          (block
-            (call_expression
-              (identifier)
-              (arguments))))))))
+                  (type_args
+                    (base_type
+                      (identifier))))
+                (arguments
+                  (call_expression
+                    (identifier)
+                    (arguments))))))
+          (assignment_expression
+            (identifier)
+            (block
+              (call_expression
+                (identifier)
+                (arguments)))))))))
 
 =========
 Interface
@@ -264,26 +267,27 @@ interface Notify
     (identifier)
     (string
       (string_content))
-    (method
-      (capability)
-      (identifier)
-      (parameters
-        (parameter
-          (identifier)
-          (base_type
-            (identifier)))
-        (parameter
-          (identifier)
-          (base_type
-            (identifier)))
-        (parameter
-          (identifier)
-          (base_type
-            (identifier))))
-      (base_type
-        (identifier))
-      (string
-        (string_content)))))
+    (members
+      (method
+        (capability)
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (base_type
+              (identifier)))
+          (parameter
+            (identifier)
+            (base_type
+              (identifier)))
+          (parameter
+            (identifier)
+            (base_type
+              (identifier))))
+        (base_type
+          (identifier))
+        (string
+          (string_content))))))
 
 =========
 Annotated

--- a/test/corpus/entity.txt
+++ b/test/corpus/entity.txt
@@ -132,10 +132,11 @@ actor Main
               (identifier)
               (identifier))
             (identifier))
-          (binary_expression
-            (string
-              (string_content))
-            (number)))))
+          (arguments
+            (binary_expression
+              (string
+                (string_content))
+              (number))))))
     (method
       (capability)
       (identifier)
@@ -164,7 +165,8 @@ actor Main
           (partial_application
             (identifier)
             (identifier))
-          (float))))))
+          (arguments
+            (float)))))))
 
 ======
 MT
@@ -231,13 +233,16 @@ class MT is Random
                 (type_args
                   (base_type
                     (identifier))))
-              (call_expression
-                (identifier)))))
+              (arguments
+                (call_expression
+                  (identifier)
+                  (arguments))))))
         (assignment_expression
           (identifier)
           (block
             (call_expression
-              (identifier))))))))
+              (identifier)
+              (arguments))))))))
 
 =========
 Interface

--- a/test/corpus/exprs.txt
+++ b/test/corpus/exprs.txt
@@ -159,16 +159,19 @@ primitive Foo
                 (base_type
                   (identifier))))
             (identifier))
-          (chain_expression
-            (array_literal
-              (block
-                (this)))
-            (call_expression
-              (member_expression
-                (call_expression
-                  (identifier)
+          (arguments
+            (chain_expression
+              (array_literal
+                (block
+                  (this)))
+              (call_expression
+                (member_expression
+                  (call_expression
+                    (identifier)
+                    (arguments (identifier))
+                  )
                   (identifier))
-                (identifier)))))))))
+                (arguments)))))))))
 
 ===================
 Block with ffi call
@@ -193,14 +196,16 @@ primitive Foo
             (identifier))
           (block
             (call_expression
-              (member_expression
-                (identifier)
-                (identifier)))))
+              (member_expression 
+                (identifier) 
+                (identifier))
+              (arguments))))
         (call_expression
           (ffi_identifier
             (identifier))
-          (string
-            (string_content)))))))
+          (arguments
+            (string
+              (string_content))))))))
 
 
 ============================================

--- a/test/corpus/exprs.txt
+++ b/test/corpus/exprs.txt
@@ -61,12 +61,13 @@ primitive Snot
 (source_file
   (primitive_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (array_literal)
-        (array_literal)))))
+    (members
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (array_literal)
+          (array_literal))))))
 
 =======================
 Strings In Block
@@ -82,14 +83,15 @@ primitive Snot
 (source_file
   (primitive_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (string
-          (string_content))
-        (string
-          (string_content))))))
+    (members
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (string
+            (string_content))
+          (string
+            (string_content)))))))
 
 ===================
 Empty Array Literal
@@ -147,31 +149,32 @@ primitive Foo
 (source_file
   (primitive_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (call_expression
-          (member_expression
-            (generic_expression
-              (identifier)
-              (type_args
-                (base_type
-                  (identifier))))
-            (identifier))
-          (arguments
-            (chain_expression
-              (array_literal
-                (block
-                  (this)))
-              (call_expression
-                (member_expression
-                  (call_expression
-                    (identifier)
-                    (arguments (identifier))
-                  )
-                  (identifier))
-                (arguments)))))))))
+    (members
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (call_expression
+            (member_expression
+              (generic_expression
+                (identifier)
+                (type_args
+                  (base_type
+                    (identifier))))
+              (identifier))
+            (arguments
+              (chain_expression
+                (array_literal
+                  (block
+                    (this)))
+                (call_expression
+                  (member_expression
+                    (call_expression
+                      (identifier)
+                      (arguments (identifier))
+                    )
+                    (identifier))
+                  (arguments))))))))))
 
 ===================
 Block with ffi call
@@ -187,25 +190,26 @@ primitive Foo
 (source_file
   (primitive_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (assignment_expression
-          (variable_declaration
-            (identifier))
-          (block
-            (call_expression
-              (member_expression 
-                (identifier) 
-                (identifier))
-              (arguments))))
-        (call_expression
-          (ffi_identifier
-            (identifier))
-          (arguments
-            (string
-              (string_content))))))))
+    (members
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (assignment_expression
+            (variable_declaration
+              (identifier))
+            (block
+              (call_expression
+                (member_expression 
+                  (identifier) 
+                  (identifier))
+                (arguments))))
+          (call_expression
+            (ffi_identifier
+              (identifier))
+            (arguments
+              (string
+                (string_content)))))))))
 
 
 ============================================
@@ -241,36 +245,37 @@ primitive Foo
       (identifier)))
   (primitive_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters)
-      (base_type
+    (members
+      (method
         (identifier)
-        (type_args
-          (base_type
-            (identifier))))
-      (block
-        (assignment_expression
-          (variable_declaration
-            (identifier)
-            (iso_type
-              (base_type
-                (identifier))))
-          (block
-            (identifier)))
-        (assignment_expression
-          (variable_declaration
-            (identifier)
-            (iso_type
-              (base_type
-                (identifier))))
-          (block
-            (identifier)))
-        (array_literal
-          (base_type
-            (identifier))
-          (block
-            (consume_statement
+        (parameters)
+        (base_type
+          (identifier)
+          (type_args
+            (base_type
+              (identifier))))
+        (block
+          (assignment_expression
+            (variable_declaration
+              (identifier)
+              (iso_type
+                (base_type
+                  (identifier))))
+            (block
+              (identifier)))
+          (assignment_expression
+            (variable_declaration
+              (identifier)
+              (iso_type
+                (base_type
+                  (identifier))))
+            (block
+              (identifier)))
+          (array_literal
+            (base_type
               (identifier))
-            (consume_statement
-              (identifier))))))))
+            (block
+              (consume_statement
+                (identifier))
+              (consume_statement
+                (identifier)))))))))

--- a/test/corpus/generics.txt
+++ b/test/corpus/generics.txt
@@ -22,24 +22,25 @@ actor Main
         (identifier))))
   (actor_definition
     (identifier)
-    (constructor
-      (identifier)
-      (parameters
-        (parameter
-          (identifier)
-          (base_type
-            (identifier))))
-      (block
+    (members
+      (constructor
         (identifier)
-        (array_literal
-          (block
-            (identifier)))))
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (generic_expression
-          (identifier)
-          (type_args
+        (parameters
+          (parameter
+            (identifier)
             (base_type
-              (identifier))))))))
+              (identifier))))
+        (block
+          (identifier)
+          (array_literal
+            (block
+              (identifier)))))
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (generic_expression
+            (identifier)
+            (type_args
+              (base_type
+                (identifier)))))))))

--- a/test/corpus/lambda.txt
+++ b/test/corpus/lambda.txt
@@ -11,43 +11,44 @@ primitive Lambda
 (source_file
   (primitive_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters
-        (parameter
-          (identifier)
-          (iso_type
-            (lambda_type
-              (capability)
-              (identifier)
-              (type_parameters
-                (generic_parameter
-                  (identifier)))
-              (lambda_parameters
-                (base_type
-                  (identifier)
-                  (type_args
-                    (base_type
-                      (identifier)))))
-              (base_type
-                (identifier))))))
-      (base_type
-        (identifier))
-      (block
-        (call_expression
-          (member_expression
+    (members
+      (method
+        (identifier)
+        (parameters
+          (parameter
             (identifier)
-            (generic_expression
-              (identifier)
-              (type_args
+            (iso_type
+              (lambda_type
+                (capability)
+                (identifier)
+                (type_parameters
+                  (generic_parameter
+                    (identifier)))
+                (lambda_parameters
+                  (base_type
+                    (identifier)
+                    (type_args
+                      (base_type
+                        (identifier)))))
                 (base_type
-                  (identifier)))))
-          (arguments
-            (generic_expression
+                  (identifier))))))
+        (base_type
+          (identifier))
+        (block
+          (call_expression
+            (member_expression
               (identifier)
-              (type_args
-                (base_type
-                  (identifier))))))))))
+              (generic_expression
+                (identifier)
+                (type_args
+                  (base_type
+                    (identifier)))))
+            (arguments
+              (generic_expression
+                (identifier)
+                (type_args
+                  (base_type
+                    (identifier)))))))))))
 
 ======
 Lambda
@@ -61,23 +62,24 @@ class Lambda
 (source_file
   (class_definition
     (identifier)
-    (field
-      (identifier)
-      (lambda_type
-        (lambda_parameters
+    (members
+      (field
+        (identifier)
+        (lambda_type
+          (lambda_parameters
+            (base_type
+              (identifier)))
           (base_type
             (identifier)))
-        (base_type
-          (identifier)))
-      (lambda_expression
-        (lambda_parameter
-          (identifier))
-        (block
-          (call_expression
-            (member_expression
-              (identifier)
-              (identifier))
-            (arguments)))))))
+        (lambda_expression
+          (lambda_parameter
+            (identifier))
+          (block
+            (call_expression
+              (member_expression
+                (identifier)
+                (identifier))
+              (arguments))))))))
 
 ========
 No Args
@@ -91,15 +93,16 @@ class Lambda
 (source_file
   (class_definition
     (identifier)
-    (field
-      (identifier)
-      (lambda_type
-        (capability)
-        (lambda_parameters))
-      (lambda_expression
-        (block
-          (identifier))
-        (capability)))))
+    (members
+      (field
+        (identifier)
+        (lambda_type
+          (capability)
+          (lambda_parameters))
+        (lambda_expression
+          (block
+            (identifier))
+          (capability))))))
 
 ===============
 Lambda Captures
@@ -115,28 +118,29 @@ class Captures
 (source_file
   (class_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (assignment_expression
-          (variable_declaration
-            (identifier))
-          (block
-            (boolean)))
-        (assignment_expression
-          (variable_declaration
-            (identifier))
-          (block
-            (lambda_expression
-              (lambda_captures
-                (identifier)
-                (base_type
+    (members
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (assignment_expression
+            (variable_declaration
+              (identifier))
+            (block
+              (boolean)))
+          (assignment_expression
+            (variable_declaration
+              (identifier))
+            (block
+              (lambda_expression
+                (lambda_captures
+                  (identifier)
+                  (base_type
+                    (identifier))
                   (identifier))
-                (identifier))
-              (block
-                (unary_expression
-                  (identifier))))))))))
+                (block
+                  (unary_expression
+                    (identifier)))))))))))
 
 ==============
 Object Literal
@@ -156,55 +160,57 @@ primitive ObjectLiteral
 (source_file
   (primitive_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (assignment_expression
-          (variable_declaration
-            (identifier))
-          (block
-            (object_literal
-              (method
-                (identifier)
-                (parameters)
-                (base_type
-                  (identifier))
-                (block
-                  (call_expression
-                    (member_expression
-                      (parenthesized_expression
-                        (chain_expression
-                          (identifier)
-                          (call_expression
-                            (identifier)
-                            (arguments))))
+    (members
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (assignment_expression
+            (variable_declaration
+              (identifier))
+            (block
+              (object_literal
+                (members
+                  (method
+                    (identifier)
+                    (parameters)
+                    (base_type
                       (identifier))
-                    (arguments))))
-              (behavior
-                (identifier)
-                (generic_parameters
-                  (generic_parameter
+                    (block
+                      (call_expression
+                        (member_expression
+                          (parenthesized_expression
+                            (chain_expression
+                              (identifier)
+                              (call_expression
+                                (identifier)
+                                (arguments))))
+                          (identifier))
+                        (arguments))))
+                  (behavior
                     (identifier)
-                    (read_type
-                      (base_type
-                        (identifier)))))
-                (parameters
-                  (parameter
-                    (identifier)
-                    (ephemeral_type
-                      (iso_type
-                        (base_type
-                          (identifier)
-                          (type_args
+                    (generic_parameters
+                      (generic_parameter
+                        (identifier)
+                        (read_type
+                          (base_type
+                            (identifier)))))
+                    (parameters
+                      (parameter
+                        (identifier)
+                        (ephemeral_type
+                          (iso_type
                             (base_type
-                              (identifier))))))))
-                (block
-                  (call_expression
-                    (member_expression
-                      (identifier)
-                      (identifier))
-                    (arguments)))))))))))
+                              (identifier)
+                              (type_args
+                                (base_type
+                                  (identifier))))))))
+                    (block
+                      (call_expression
+                        (member_expression
+                          (identifier)
+                          (identifier))
+                        (arguments)))))))))))))
 
 ===========
 Bare Lambda
@@ -237,61 +243,62 @@ actor Main
             (identifier))))))
   (actor_definition
     (identifier)
-    (constructor
-      (identifier)
-      (parameters
-        (parameter
-          (identifier)
-          (base_type
-            (identifier))))
-      (block
-        (assignment_expression
-          (variable_declaration
-            (identifier))
-          (block
-            (call_expression
-              (ffi_identifier
-                (identifier))
-              (arguments
-                (number)))))
-        (assignment_expression
-          (variable_declaration
+    (members
+      (constructor
+        (identifier)
+        (parameters
+          (parameter
             (identifier)
-            (lambda_type
-              (lambda_parameters
-                (base_type
-                  (identifier))
-                (base_type
-                  (identifier)))
-              (base_type
-                (identifier))))
-          (block
-            (call_expression
-              (generic_expression
+            (base_type
+              (identifier))))
+        (block
+          (assignment_expression
+            (variable_declaration
+              (identifier))
+            (block
+              (call_expression
                 (ffi_identifier
                   (identifier))
-                (type_args
-                  (lambda_type
-                    (lambda_parameters
-                      (base_type
-                        (identifier))
-                      (base_type
-                        (identifier)))
-                    (base_type
-                      (identifier)))))
-              (arguments
-                (number)))))
-        (assignment_expression
-          (variable_declaration
-            (identifier))
-          (block
-            (call_expression
+                (arguments
+                  (number)))))
+          (assignment_expression
+            (variable_declaration
               (identifier)
-              (arguments
-                (call_expression
-                  (identifier)
-                  (arguments
-                    (number)))
-                (call_expression
-                  (identifier)
-                  (arguments (number)))))))))))
+              (lambda_type
+                (lambda_parameters
+                  (base_type
+                    (identifier))
+                  (base_type
+                    (identifier)))
+                (base_type
+                  (identifier))))
+            (block
+              (call_expression
+                (generic_expression
+                  (ffi_identifier
+                    (identifier))
+                  (type_args
+                    (lambda_type
+                      (lambda_parameters
+                        (base_type
+                          (identifier))
+                        (base_type
+                          (identifier)))
+                      (base_type
+                        (identifier)))))
+                (arguments
+                  (number)))))
+          (assignment_expression
+            (variable_declaration
+              (identifier))
+            (block
+              (call_expression
+                (identifier)
+                (arguments
+                  (call_expression
+                    (identifier)
+                    (arguments
+                      (number)))
+                  (call_expression
+                    (identifier)
+                    (arguments (number))))))))))))

--- a/test/corpus/lambda.txt
+++ b/test/corpus/lambda.txt
@@ -42,11 +42,12 @@ primitive Lambda
               (type_args
                 (base_type
                   (identifier)))))
-          (generic_expression
-            (identifier)
-            (type_args
-              (base_type
-                (identifier)))))))))
+          (arguments
+            (generic_expression
+              (identifier)
+              (type_args
+                (base_type
+                  (identifier))))))))))
 
 ======
 Lambda
@@ -75,7 +76,8 @@ class Lambda
           (call_expression
             (member_expression
               (identifier)
-              (identifier))))))))
+              (identifier))
+            (arguments)))))))
 
 ========
 No Args
@@ -175,8 +177,10 @@ primitive ObjectLiteral
                         (chain_expression
                           (identifier)
                           (call_expression
-                            (identifier))))
-                      (identifier)))))
+                            (identifier)
+                            (arguments))))
+                      (identifier))
+                    (arguments))))
               (behavior
                 (identifier)
                 (generic_parameters
@@ -199,7 +203,8 @@ primitive ObjectLiteral
                   (call_expression
                     (member_expression
                       (identifier)
-                      (identifier))))))))))))
+                      (identifier))
+                    (arguments)))))))))))
 
 ===========
 Bare Lambda
@@ -247,7 +252,8 @@ actor Main
             (call_expression
               (ffi_identifier
                 (identifier))
-              (number))))
+              (arguments
+                (number)))))
         (assignment_expression
           (variable_declaration
             (identifier)
@@ -273,16 +279,19 @@ actor Main
                         (identifier)))
                     (base_type
                       (identifier)))))
-              (number))))
+              (arguments
+                (number)))))
         (assignment_expression
           (variable_declaration
             (identifier))
           (block
             (call_expression
               (identifier)
-              (call_expression
-                (identifier)
-                (number))
-              (call_expression
-                (identifier)
-                (number)))))))))
+              (arguments
+                (call_expression
+                  (identifier)
+                  (arguments
+                    (number)))
+                (call_expression
+                  (identifier)
+                  (arguments (number)))))))))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -16,35 +16,36 @@ primitive ContainsWith
 (source_file
   (primitive_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (with_statement
-          (with_elem
-            (identifier)
-            (block
-              (call_expression
-                (identifier)
-                (arguments))))
-          (with_elem
-            (identifier)
-            (block
-              (call_expression
-                (identifier)
-                (arguments))))
-          (do_block
-            (line_comment)
-            (block
-              (call_expression
-                (member_expression
-                  (identifier)
-                  (identifier))
-                (arguments
-                  (identifier))))
-            (else_block
+    (members
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (with_statement
+            (with_elem
+              (identifier)
               (block
-                (identifier)))))))))
+                (call_expression
+                  (identifier)
+                  (arguments))))
+            (with_elem
+              (identifier)
+              (block
+                (call_expression
+                  (identifier)
+                  (arguments))))
+            (do_block
+              (line_comment)
+              (block
+                (call_expression
+                  (member_expression
+                    (identifier)
+                    (identifier))
+                  (arguments
+                    (identifier))))
+              (else_block
+                (block
+                  (identifier))))))))))
 
 ========
 If Block
@@ -63,20 +64,21 @@ primitive Foo
 (source_file
   (primitive_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (if_statement
-          (if_block
-            (block
-              (string
-                (string_content))
-              (boolean)))
-          (then_block
-            (block
-              (string
-                (string_content)))))))))
+    (members
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (if_statement
+            (if_block
+              (block
+                (string
+                  (string_content))
+                (boolean)))
+            (then_block
+              (block
+                (string
+                  (string_content))))))))))
 
 ======
 Iftype
@@ -100,20 +102,12 @@ primitive Foo[A]
     (generic_parameters
       (generic_parameter
         (identifier)))
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (iftype_statement
-          (base_type
-            (identifier))
-          (base_type
-            (identifier))
-          (then_block
-            (block
-              (string
-                (string_content))))
-          (elseiftype_block
+    (members
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (iftype_statement
             (base_type
               (identifier))
             (base_type
@@ -121,11 +115,20 @@ primitive Foo[A]
             (then_block
               (block
                 (string
-                  (string_content)))))
-          (else_block
-            (block
-              (string
-                (string_content)))))))))
+                  (string_content))))
+            (elseiftype_block
+              (base_type
+                (identifier))
+              (base_type
+                (identifier))
+              (then_block
+                (block
+                  (string
+                    (string_content)))))
+            (else_block
+              (block
+                (string
+                  (string_content))))))))))
 
 ========
 For Loop
@@ -153,44 +156,45 @@ primitive Snot
 (source_file
   (primitive_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (for_statement
-          (identifier)
-          (call_expression
-            (member_expression
-              (array_literal)
-              (identifier)
+    (members
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (for_statement
+            (identifier)
+            (call_expression
+              (member_expression
+                (array_literal)
+                (identifier)
+              )
+              (arguments)
             )
-            (arguments)
-          )
-          (do_block
-            (block
-              (while_statement
-                (boolean)
-                (do_block
-                  (block
-                    (repeat_statement
-                      (block
-                        (identifier))
-                      (binary_expression
-                        (identifier)
-                        (boolean))
-                      (else_block
-                        (block
-                          (string
-                            (string_content))))
-                      (line_comment)))
-                  (else_block
-                    (block
-                      (string
-                        (string_content)))))))
-            (else_block
+            (do_block
               (block
-                (string
-                  (string_content))))))))))
+                (while_statement
+                  (boolean)
+                  (do_block
+                    (block
+                      (repeat_statement
+                        (block
+                          (identifier))
+                        (binary_expression
+                          (identifier)
+                          (boolean))
+                        (else_block
+                          (block
+                            (string
+                              (string_content))))
+                        (line_comment)))
+                    (else_block
+                      (block
+                        (string
+                          (string_content)))))))
+              (else_block
+                (block
+                  (string
+                    (string_content)))))))))))
 
 =============
 Try Statement
@@ -212,23 +216,24 @@ primitive Foo
 (source_file
   (primitive_definition
     (identifier)
-    (method
-      (identifier)
-      (parameters)
-      (block
-        (try_statement
-          (block
-            (call_expression
-              (member_expression
-                (identifier)
-                (identifier))
-              (arguments))
-            (error))
-          (else_block
+    (members
+      (method
+        (identifier)
+        (parameters)
+        (block
+          (try_statement
             (block
-              (string
-                (string_content))))
-          (then_block
-            (block
-              (string
-                (string_content)))))))))
+              (call_expression
+                (member_expression
+                  (identifier)
+                  (identifier))
+                (arguments))
+              (error))
+            (else_block
+              (block
+                (string
+                  (string_content))))
+            (then_block
+              (block
+                (string
+                  (string_content))))))))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -25,12 +25,14 @@ primitive ContainsWith
             (identifier)
             (block
               (call_expression
-                (identifier))))
+                (identifier)
+                (arguments))))
           (with_elem
             (identifier)
             (block
               (call_expression
-                (identifier))))
+                (identifier)
+                (arguments))))
           (do_block
             (line_comment)
             (block
@@ -38,7 +40,8 @@ primitive ContainsWith
                 (member_expression
                   (identifier)
                   (identifier))
-                (identifier)))
+                (arguments
+                  (identifier))))
             (else_block
               (block
                 (identifier)))))))))
@@ -161,6 +164,7 @@ primitive Snot
               (array_literal)
               (identifier)
             )
+            (arguments)
           )
           (do_block
             (block
@@ -217,7 +221,8 @@ primitive Foo
             (call_expression
               (member_expression
                 (identifier)
-                (identifier)))
+                (identifier))
+              (arguments))
             (error))
           (else_block
             (block

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -14,39 +14,40 @@ class Array[A]
     (generic_parameters
       (generic_parameter
         (identifier)))
-    (method
-      (capability)
-      (identifier)
-      (generic_parameters
-        (generic_parameter
-          (identifier)
-          (intersection_type
-            (base_type
-              (identifier))
-            (send_type
+    (members
+      (method
+        (capability)
+        (identifier)
+        (generic_parameters
+          (generic_parameter
+            (identifier)
+            (intersection_type
               (base_type
-                (identifier))))
-          (base_type
-            (identifier))))
-      (parameters
-        (parameter
-          (identifier)
-          (base_type
-            (identifier))))
-      (tuple_type
-        (ephemeral_type
-          (iso_type
-            (base_type
-              (identifier)
-              (type_args
+                (identifier))
+              (send_type
                 (base_type
-                  (identifier))))))
-        (ephemeral_type
-          (iso_type
+                  (identifier))))
             (base_type
-              (identifier)
-              (type_args
-                (base_type
-                  (identifier)))))))
-      (block
-        (identifier)))))
+              (identifier))))
+        (parameters
+          (parameter
+            (identifier)
+            (base_type
+              (identifier))))
+        (tuple_type
+          (ephemeral_type
+            (iso_type
+              (base_type
+                (identifier)
+                (type_args
+                  (base_type
+                    (identifier))))))
+          (ephemeral_type
+            (iso_type
+              (base_type
+                (identifier)
+                (type_args
+                  (base_type
+                    (identifier)))))))
+        (block
+          (identifier))))))


### PR DESCRIPTION
* Needed call arguments for proper textobject queries for call arguments.
* The special builtin `__loc` was missing an only detected as an identifier. Now it can be highlighted as a builtin variable.
* Add a node for `named_argument` to catch the name and the value
* Added a node for all `members` to support `@class.inside` captures.